### PR TITLE
Search and update buy qty bug

### DIFF
--- a/src/views/UserProducts.vue
+++ b/src/views/UserProducts.vue
@@ -215,6 +215,7 @@ export default {
       forCategoryAllProducts: [],
       currentCategory: "選擇類別",
       searchText: "",
+      searchResult: [],
       getOtherPageProducts: throttle(
         function (options = this.pagination) {
           const { current_page, total_pages } = options;
@@ -488,6 +489,7 @@ export default {
     this.emitter.on("productSearchResult", (searchResult) => {
       this.searchText = searchResult[0];
       this.pagination.total_pages = 0;
+      this.searchResult = searchResult.data;
       this.allProducts = searchResult.data;
       this.pushBuyQtyId();
     });
@@ -502,6 +504,9 @@ export default {
   updated() {
     if (this.$route.path === "/favorite") {
       this.allProducts = this.myFavoriteList;
+    if (this.searchText !== "") {
+      this.allProducts = this.searchResult;
+      this.getCart();
       this.pushBuyQtyId();
     }
   },

--- a/src/views/UserProducts.vue
+++ b/src/views/UserProducts.vue
@@ -457,9 +457,6 @@ export default {
         })
         .catch((error) => {
           this.$pushMsg.status404(error.response.data.message);
-        })
-        .finally(() => {
-          location.reload();
         });
     },
     goToProduct(item) {
@@ -504,6 +501,9 @@ export default {
   updated() {
     if (this.$route.path === "/favorite") {
       this.allProducts = this.myFavoriteList;
+      this.getCart();
+      this.pushBuyQtyId();
+    }
     if (this.searchText !== "") {
       this.allProducts = this.searchResult;
       this.getCart();


### PR DESCRIPTION
在搜尋後的頁面更改購買數量，可以維持在原頁面，不跳轉到所有商品頁
在收藏商品頁面，刪除購買數量歸零時，不須重整即可呈現正確的 UI （數量的 UI 會消除）
