### PR TITLE
Home page over x

### DIFF
--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -59,16 +59,16 @@
   <div class="row col-12 mx-0 justify-content-center align-items-center">
     <img
       class="newsImg object-fit-cover col-lg-12 p-0"
-      data-aos="fade-right"
+      data-aos="fade-zoom-in"
       data-aos-easing="ease-out-circ"
-      data-aos-duration="1000"
+      data-aos-duration="2000"
       src="../assets/img/home_img2.jpg"
       alt="homeImg"
     />
     <router-link
       to="/user-products"
       class="newsContent text-decoration-none text-black col-11 col-sm-9 col-lg-8 col-xl-6 d-flex flex-column justify-content-center align-items-center"
-      data-aos="zoom-in-left"
+      data-aos="zoom-in"
       data-aos-easing="ease-out-sine"
       data-aos-duration="900"
     >

--- a/src/views/UserProducts.vue
+++ b/src/views/UserProducts.vue
@@ -181,7 +181,6 @@
       </div>
     </div>
   </div>
-
   <Observer
     v-if="pagination.current_page < pagination.total_pages"
     @is-in-view="handleIsInView"
@@ -479,7 +478,6 @@ export default {
       );
     },
   },
-
   created() {
     this.isLoading = true;
     this.whereComeFrom();


### PR DESCRIPTION
**動態畫面原為左右各自進入畫面中，會在還沒進入前呈現有Ｘ軸（手機版面）進入後則消失Ｘ軸，改為不需左右各自進入方式**

![CleanShot 2024-06-12 at 09 36 10](https://github.com/c711cat/fresh_box/assets/77562017/dd9ff55d-8648-4977-8629-329c9e21e4a0)

![CleanShot 2024-06-12 at 09 37 16](https://github.com/c711cat/fresh_box/assets/77562017/33b8c5e8-315c-4526-b1c7-55bba7337ca8)

![CleanShot 2024-06-12 at 09 39 12](https://github.com/c711cat/fresh_box/assets/77562017/edd9a66f-d4fc-4a4d-a6c7-5cca651e719e)
