### PR TITLE
Modify order UI

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,5 @@
 <template>
-  <MessagesView></MessagesView>
+  <MessagesView />
   <router-view />
 </template>
 

--- a/src/components/MessagesView.vue
+++ b/src/components/MessagesView.vue
@@ -1,10 +1,6 @@
 <template>
   <div class="toast-container end-0 mt-3 container-fluid">
-    <ToastView
-      v-for="(msg, index) in messages"
-      :key="msg + index"
-      :msg="msg"
-    ></ToastView>
+    <ToastView v-for="(msg, index) in messages" :key="msg + index" :msg="msg" />
   </div>
 </template>
 

--- a/src/components/OrderView.vue
+++ b/src/components/OrderView.vue
@@ -20,48 +20,46 @@
       <section
         v-for="item in order.products"
         :key="item.id"
-        class="row m-0 justify-content-center align-items-center border-top pt-3 pb-3"
+        class="row m-0 justify-content-around align-items-center border-top pt-3 pb-3"
       >
         <router-link
           :to="`/product/${item.product.id}`"
-          class="d-none d-sm-block col-sm-2 col-xxl-1 m-0 text-center p-0"
+          class="col-auto m-0 text-center p-0"
         >
-          <img class="imgBody" :src="item.product.imageUrl" alt="" />
+          <img class="imgBody" :src="item.product.imageUrl" alt="product-img" />
         </router-link>
         <div
-          class="col-7 col-sm-6 col-md-4 col-lg-5 col-xl-4 col-xxl-7 row mx-0 my-1 align-items-center"
+          class="row mx-0 my-1 px-0 col-9 col-sm-10 align-items-center flex-wrap"
         >
-          <router-link
-            :to="`/product/${item.product.id}`"
-            class="col-md-12 col-lg-12 col-xl-12 col-xxl-4 titleLink"
-          >
-            {{ item.product.title }}
-          </router-link>
-          <div class="col-md-12 col-lg-12 col-xl-12 col-xxl-4">
+          <div class="col-12">
+            <router-link :to="`/product/${item.product.id}`" class="titleLink">
+              {{ item.product.title }}
+            </router-link>
+          </div>
+
+          <div class="col-12 col-md-4 col-xl-12 col-xxl-3">
             {{ item.product.content }}／{{ item.product.unit }}
           </div>
+
           <div
             v-if="item.product.origin_price === item.product.price"
-            class="text-secondary col-md-12 col-lg-12 col-xl-12 col-xxl-4"
+            class="text-secondary col-12 col-md-3 col-xl-4 col-xxl-3"
           >
             NT$ {{ $filters.currency(item.product.origin_price) }}
           </div>
-          <div
-            v-else
-            class="text-danger fw-bold col-md-12 col-lg-12 col-xl-12 col-xxl-4"
-          >
+          <div v-else class="text-secondary col-12 col-md-3 col-xl-4 col-xxl-3">
             NT$ {{ $filters.currency(item.product.price) }}
           </div>
-        </div>
 
-        <div
-          class="row m-0 align-items-center col-5 col-sm-4 col-md-6 col-lg-5 col-xl-4 col-xxl-4"
-        >
-          <div class="py-2 d-flex col-12 col-sm-12 col-md-6 col-lg-6 col-xl-6">
-            數量：{{ item.qty }}
+          <div
+            class="col-auto col-sm-6 col-md-2 col-xl-4 col-xxl-2 d-inline-block"
+          >
+            {{ item.qty }} 件
           </div>
 
-          <div class="my-2 col-12 col-sm-12 col-md-6 col-lg-6 col-xl-6">
+          <div
+            class="col-auto ms-auto col-sm-6 col-md-3 col-xl-4 col-xxl-4 fw-bold text-end d-inline-block"
+          >
             NT$ {{ $filters.currency(item.total) }}
           </div>
         </div>
@@ -270,7 +268,8 @@ export default {
 }
 
 .imgBody {
-  width: 50px;
+  width: 60px;
+  height: 90px;
   object-fit: cover;
 }
 

--- a/src/components/OrderView.vue
+++ b/src/components/OrderView.vue
@@ -41,14 +41,8 @@
             {{ item.product.content }}／{{ item.product.unit }}
           </div>
 
-          <div
-            v-if="item.product.origin_price === item.product.price"
-            class="text-secondary col-12 col-md-3 col-xl-4 col-xxl-3"
-          >
-            NT$ {{ $filters.currency(item.product.origin_price) }}
-          </div>
-          <div v-else class="text-secondary col-12 col-md-3 col-xl-4 col-xxl-3">
-            NT$ {{ $filters.currency(item.product.price) }}
+          <div class="text-secondary col-12 col-md-3 col-xl-4 col-xxl-3">
+            NT$ {{ $filters.currency(showPrice(item)) }}
           </div>
 
           <div
@@ -248,6 +242,13 @@ export default {
     },
     turnDate(date) {
       return new Date(date * 1000).toLocaleString("taiwan", { hour12: false });
+    },
+    showPrice(item) {
+      if (item.product.origin_price === item.product.price) {
+        return item.product.origin_price;
+      } else {
+        return item.product.price;
+      }
     },
   },
   computed: {

--- a/src/components/OrderView.vue
+++ b/src/components/OrderView.vue
@@ -4,7 +4,7 @@
       <header
         class="d-flex align-items-center justify-content-between flex-wrap"
       >
-        <h3 class="ps-3">訂單明細</h3>
+        <h3 class="">訂單明細</h3>
         <div class="ps-3">
           <p class="orderId mb-0">訂單日期 {{ turnDate(order.create_at) }}</p>
           <p class="orderId mb-0">訂單編號 {{ order.id }}</p>
@@ -62,16 +62,16 @@
       </section>
 
       <section
-        class="col-12 row g-1 m-0 border-top py-3 justify-content-center align-items-center"
+        class="col-12 row g-1 m-0 border-top py-3 justify-content-between align-items-center"
       >
-        <div class="col-6 col-sm-7 col-lg-8 col-xl-9 text-sm-end">小計</div>
+        <div class="col-7 col-sm-8 col-lg-9 col-xl-10 text-sm-end">小計</div>
         <div class="col-5 col-sm-4 col-lg-3 col-xl-2 text-end">
           NT$ {{ $filters.currency(order.subtotal) }}
         </div>
 
         <div
           v-if="order.discount > 0"
-          class="col-6 col-sm-7 col-lg-8 col-xl-9 text-sm-end"
+          class="col-7 col-sm-8 col-lg-9 col-xl-10 text-sm-end"
         >
           優惠碼折抵
         </div>
@@ -83,7 +83,7 @@
         </div>
         <div
           v-if="order.discount > 0"
-          class="col-6 col-sm-7 col-lg-8 col-xl-9 text-sm-end"
+          class="col-7 col-sm-8 col-lg-9 col-xl-10 text-sm-end"
         >
           折抵後小計
         </div>
@@ -94,7 +94,7 @@
           NT$ {{ $filters.currency(order.afterDiscount) }}
         </div>
 
-        <div class="col-6 col-sm-7 col-lg-8 col-xl-9 text-sm-end">
+        <div class="col-7 col-sm-8 col-lg-9 col-xl-10 text-sm-end">
           冷藏宅配
           <div class="col-12 text-yellow-600">
             <i class="bi bi-info-circle"></i>
@@ -108,7 +108,7 @@
 
         <strong
           :class="paymentAmountColor"
-          class="col-6 col-sm-7 col-lg-8 col-xl-9 text-sm-end"
+          class="col-7 col-sm-8 col-lg-9 col-xl-10 text-sm-end"
         >
           付款金額
         </strong>
@@ -118,7 +118,7 @@
         >
           NT$ {{ $filters.currency(order.paymentAmount) }}
         </strong>
-        <strong class="col-6 col-sm-7 col-lg-8 col-xl-9 text-sm-end">
+        <strong class="col-7 col-sm-8 col-lg-9 col-xl-10 text-sm-end">
           付款狀態
         </strong>
         <strong
@@ -130,7 +130,7 @@
       </section>
     </div>
     <section class="col-lg-5">
-      <h3 class="border-bottom pb-2 ps-3">收件人資訊</h3>
+      <h3 class="border-bottom pb-2">收件人資訊</h3>
       <div class="px-4 mb-2 d-flex flex-wrap">
         <p class="mb-0 py-1 fw-bold col-sm-2 col-12">姓名</p>
         <p class="mb-0 py-1 col-sm-10 col-12">{{ order.user.name }}</p>

--- a/src/components/OrderView.vue
+++ b/src/components/OrderView.vue
@@ -66,71 +66,88 @@
       </section>
 
       <section
-        class="col-12 row g-1 m-0 border-top py-3 justify-content-between align-items-center"
+        class="col-12 row g-1 m-0 border-top py-3 justify-content-between align-items-center space"
       >
-        <div class="col-7 col-sm-8 col-lg-9 col-xl-10 text-sm-end">小計</div>
-        <div class="col-5 col-sm-4 col-lg-3 col-xl-2 text-end">
-          NT$ {{ $filters.currency(order.subtotal) }}
-        </div>
-
-        <div
-          v-if="order.discount > 0"
-          class="col-7 col-sm-8 col-lg-9 col-xl-10 text-sm-end"
-        >
-          優惠碼折抵
-        </div>
-        <div
-          v-if="order.discount > 0"
-          class="col-5 col-sm-4 col-lg-3 col-xl-2 text-end"
-        >
-          - NT$ {{ $filters.currency(order.discount) }}
-        </div>
-        <div
-          v-if="order.discount > 0"
-          class="col-7 col-sm-8 col-lg-9 col-xl-10 text-sm-end"
-        >
-          折抵後小計
-        </div>
-        <div
-          v-if="order.discount > 0"
-          class="col-5 col-sm-4 col-lg-3 col-xl-2 text-end"
-        >
-          NT$ {{ $filters.currency(order.afterDiscount) }}
-        </div>
-
-        <div class="col-7 col-sm-8 col-lg-9 col-xl-10 text-sm-end">
-          冷藏宅配
-          <div class="col-12 text-yellow-600">
-            <i class="bi bi-info-circle"></i>
-            滿 NT$ 1,000 免運
+        <div class="d-flex flex-wrap col-12">
+          <div
+            class="col-4 col-sm-9 col-md-10 col-lg-9 col-xl-9 col-xxl-9 text-sm-end fw-bold"
+          >
+            小計
+          </div>
+          <div
+            class="col-8 col-sm-3 col-md-2 col-lg-3 col-xl-3 col-xxl-3 text-end fw-bold"
+          >
+            NT$ {{ $filters.currency(order.subtotal) }}
           </div>
         </div>
-
-        <div class="col-5 col-sm-4 col-lg-3 col-xl-2 text-end">
-          NT$ {{ order.shippingFee }}
+        <div v-if="order.discount > 0" class="d-flex col-12">
+          <div
+            class="col-4 col-sm-9 col-md-10 col-lg-9 col-xl-9 col-xxl-9 text-sm-end"
+          >
+            優惠碼折抵
+          </div>
+          <div
+            class="col-8 col-sm-3 col-md-2 col-lg-3 col-xl-3 col-xxl-3 text-end"
+          >
+            - NT$ {{ $filters.currency(order.discount) }}
+          </div>
         </div>
-
-        <strong
-          :class="paymentAmountColor"
-          class="col-7 col-sm-8 col-lg-9 col-xl-10 text-sm-end"
-        >
-          付款金額
-        </strong>
-        <strong
-          :class="paymentAmountColor"
-          class="col-5 col-sm-4 col-lg-3 col-xl-2 text-end"
-        >
-          NT$ {{ $filters.currency(order.paymentAmount) }}
-        </strong>
-        <strong class="col-7 col-sm-8 col-lg-9 col-xl-10 text-sm-end">
-          付款狀態
-        </strong>
-        <strong
-          :class="paymentStatusColor"
-          class="col-5 col-sm-4 col-lg-3 col-xl-2 text-end"
-        >
-          {{ paymentStatus }}
-        </strong>
+        <div v-if="order.discount > 0" class="d-flex col-12">
+          <div
+            class="col-4 col-sm-9 col-md-10 col-lg-9 col-xl-9 col-xxl-9 text-sm-end"
+          >
+            折抵後小計
+          </div>
+          <div
+            class="col-8 col-sm-3 col-md-2 col-lg-3 col-xl-3 col-xxl-3 text-end"
+          >
+            NT$ {{ $filters.currency(order.afterDiscount) }}
+          </div>
+        </div>
+        <div class="d-flex flex-wrap col-12">
+          <div
+            class="col-4 col-sm-9 col-md-10 col-lg-9 col-xl-9 col-xxl-9 text-sm-end"
+          >
+            冷藏宅配
+          </div>
+          <div
+            class="col-8 col-sm-3 col-md-2 col-lg-3 col-xl-3 col-xxl-3 text-end"
+          >
+            NT$ {{ order.shippingFee }}
+          </div>
+          <div
+            class="d-flex text-primary col-12 col-sm-9 col-md-10 col-lg-9 col-xl-9 col-xxl-9"
+          >
+            <p class="mb-0 w-100 text-sm-end">
+              <i class="bi bi-info-circle me-1"></i>滿 NT$ 1,000 免運
+            </p>
+          </div>
+        </div>
+        <div class="d-flex col-12">
+          <strong
+            class="col-4 col-sm-9 col-md-10 col-lg-9 col-xl-9 col-xxl-9 text-sm-end"
+          >
+            付款金額
+          </strong>
+          <strong
+            class="col-8 col-sm-3 col-md-2 col-lg-3 col-xl-3 col-xxl-3 text-end text-primary"
+          >
+            NT$ {{ $filters.currency(order.paymentAmount) }}
+          </strong>
+        </div>
+        <div class="d-flex col-12">
+          <strong
+            class="col-4 col-sm-9 col-md-10 col-lg-9 col-xl-9 col-xxl-9 text-sm-end"
+          >
+            付款狀態
+          </strong>
+          <strong
+            :class="paymentStatusColor"
+            class="col-8 col-sm-3 col-md-2 col-lg-3 col-xl-3 col-xxl-3 text-end"
+          >
+            {{ paymentStatus }}
+          </strong>
+        </div>
       </section>
     </div>
     <section class="col-lg-5">
@@ -248,13 +265,6 @@ export default {
         return "text-danger";
       }
     },
-    paymentAmountColor() {
-      if (this.order.is_paid === true) {
-        return "";
-      } else {
-        return "text-danger";
-      }
-    },
   },
   created() {
     this.getOrder();
@@ -284,5 +294,10 @@ export default {
 
 .titleLink:hover {
   font-weight: bold;
+}
+
+.space {
+  row-gap: 12px;
+  column-gap: 12px;
 }
 </style>

--- a/src/components/OrderView.vue
+++ b/src/components/OrderView.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="row m-0 p-0">
-    <div class="detailsText pb-2 col-lg-7">
+    <div class="detailsText mb-4 col-lg-7">
       <header
         class="d-flex align-items-center justify-content-between flex-wrap"
       >
@@ -152,7 +152,9 @@
       </div>
       <div class="px-4 mb-2 d-flex flex-wrap">
         <p class="mb-0 py-1 fw-bold col-sm-2 col-12">email</p>
-        <p class="mb-0 py-1 col-sm-10 col-12">{{ order.user.email }}</p>
+        <p class="wrapText mb-0 py-1 col-sm-10 col-12">
+          {{ order.user.email }}
+        </p>
       </div>
       <div class="px-4 mb-2 d-flex flex-wrap">
         <p class="mb-0 py-1 fw-bold col-sm-2 col-12">電話</p>
@@ -300,5 +302,9 @@ export default {
 .space {
   row-gap: 12px;
   column-gap: 12px;
+}
+
+.wrapText {
+  word-wrap: break-word;
 }
 </style>

--- a/src/components/OrderView.vue
+++ b/src/components/OrderView.vue
@@ -4,10 +4,16 @@
       <header
         class="d-flex align-items-center justify-content-between flex-wrap"
       >
-        <h3 class="">訂單明細</h3>
-        <div class="ps-3">
-          <p class="orderId mb-0">訂單日期 {{ turnDate(order.create_at) }}</p>
-          <p class="orderId mb-0">訂單編號 {{ order.id }}</p>
+        <h3>訂單明細</h3>
+        <div>
+          <p class="orderId mb-0">
+            訂單日期
+            <span class="d-inline-block">{{ turnDate(order.create_at) }}</span>
+          </p>
+          <p class="orderId mb-0">
+            訂單編號
+            <span class="d-inline-block"> {{ order.id }}</span>
+          </p>
         </div>
       </header>
 

--- a/src/views/backend/Admin'sProducts.vue
+++ b/src/views/backend/Admin'sProducts.vue
@@ -94,7 +94,7 @@
       v-if="openPagination"
       :pages="pagination"
       @emit-pages="getProducts"
-    ></PaginationView>
+    />
   </main>
 
   <ProductModal

--- a/src/views/backend/AdminCoupons.vue
+++ b/src/views/backend/AdminCoupons.vue
@@ -87,12 +87,8 @@
     @add-coupon="addCoupon"
     :coupon="tempCoupon"
     ref="couponModal"
-  ></CouponModal>
-  <DelModal
-    ref="delModal"
-    @del-coupon="delCoupon"
-    :coupon="tempCoupon"
-  ></DelModal>
+  />
+  <DelModal ref="delModal" @del-coupon="delCoupon" :coupon="tempCoupon" />
 </template>
 
 <script>

--- a/src/views/backend/AdminDashboard.vue
+++ b/src/views/backend/AdminDashboard.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="navContainer">
-    <AdminNavbar></AdminNavbar>
+    <AdminNavbar />
   </div>
 
   <div class="viewContainer">

--- a/src/views/backend/AdminQA.vue
+++ b/src/views/backend/AdminQA.vue
@@ -71,19 +71,11 @@
       </div>
     </section>
     <footer>
-      <PaginationView
-        :pages="pagination"
-        @emit-pages="getQAList"
-      ></PaginationView>
+      <PaginationView :pages="pagination" @emit-pages="getQAList" />
     </footer>
   </main>
-  <QA_Modal
-    ref="QA_Modal"
-    :QA="tempQA"
-    @add-QA="addQA"
-    @edit-QA="editQA"
-  ></QA_Modal>
-  <DelModal ref="delModal" :QA="tempQA" @del-QA="delQA"></DelModal>
+  <QA_Modal ref="QA_Modal" :QA="tempQA" @add-QA="addQA" @edit-QA="editQA" />
+  <DelModal ref="delModal" :QA="tempQA" @del-QA="delQA" />
 </template>
 <script>
 import Collapse from "bootstrap/js/dist/collapse";

--- a/src/views/frontend/CartView.vue
+++ b/src/views/frontend/CartView.vue
@@ -55,14 +55,8 @@
                 ></i>
               </div>
 
-              <div
-                v-if="item.product.origin_price === item.product.price"
-                class="text-secondary pb-1"
-              >
-                NT$ {{ $filters.currency(item.product.origin_price) }}
-              </div>
-              <div v-else class="text-secondary pb-1">
-                NT$ {{ $filters.currency(item.product.price) }}
+              <div class="text-secondary pb-1">
+                NT$ {{ $filters.currency(showPrice(item)) }}
               </div>
 
               <div class="d-flex flex-wrap justify-content-between">
@@ -361,6 +355,13 @@ export default {
     },
     getCurrentWidth() {
       this.currentWidth = window.outerWidth;
+    },
+    showPrice(item) {
+      if (item.product.origin_price === item.product.price) {
+        return item.product.origin_price;
+      } else {
+        return item.product.price;
+      }
     },
   },
   computed: {

--- a/src/views/frontend/CartView.vue
+++ b/src/views/frontend/CartView.vue
@@ -163,7 +163,7 @@
     ref="delModal"
     :allCartItems="allCartItems"
     @del-all-items-of-Cart="cleanCart"
-  ></delModal>
+  />
 </template>
 
 <script>

--- a/src/views/frontend/HomeView.vue
+++ b/src/views/frontend/HomeView.vue
@@ -9,7 +9,7 @@
   />
 
   <!-- 商品類別 -->
-  <CategoryView></CategoryView>
+  <CategoryView />
   <!-- 暢銷商品 -->
   <section class="d-flex justify-content-center mt-5">
     <div class="row mx-0 mb-5 pb-3 pt-4 col-11 justify-content-center">
@@ -106,7 +106,7 @@
           data-aos="fade-up"
           data-aos-easing="ease-out-sine"
           data-aos-duration="800"
-        ></SwiperImgs>
+        />
       </div>
     </div>
   </section>

--- a/src/views/frontend/ProductDetails.vue
+++ b/src/views/frontend/ProductDetails.vue
@@ -132,7 +132,7 @@
             </h2>
             <div id="shopping-notes" class="accordion-collapse collapse show">
               <div class="accordion-body border-top">
-                <ShoppingNotes></ShoppingNotes>
+                <ShoppingNotes />
               </div>
             </div>
           </section>
@@ -151,14 +151,14 @@
             </h2>
             <div id="exception-SOP" class="accordion-collapse collapse show">
               <div class="accordion-body border-top">
-                <ExceptionSOP></ExceptionSOP>
+                <ExceptionSOP />
               </div>
             </div>
           </section>
         </div>
       </div>
       <h3 class="mb-4 pb-3 pt-5 col-10 border-bottom">推薦商品</h3>
-      <SwiperImgs class="col-lg-10"></SwiperImgs>
+      <SwiperImgs class="col-lg-10" />
     </div>
   </div>
 </template>

--- a/src/views/frontend/UserDashboard.vue
+++ b/src/views/frontend/UserDashboard.vue
@@ -1,12 +1,12 @@
 <template>
   <div class="userViewContainer">
     <div>
-      <UserNavbar :currentPath="$route.path"></UserNavbar>
+      <UserNavbar :currentPath="$route.path" />
       <router-view />
     </div>
 
     <div>
-      <FooterView></FooterView>
+      <FooterView />
     </div>
   </div>
 </template>

--- a/src/views/frontend/UserOrder.vue
+++ b/src/views/frontend/UserOrder.vue
@@ -1,37 +1,34 @@
 <template>
   <LoadingView v-if="isLoading" />
-  <main v-else class="mt-5 pt-4">
+  <main v-else class="mt-5 pt-4 mb-5">
     <section
       class="mx-2 mt-5 mx-auto col-11 col-sm-11 col-md-10 col-lg-11 col-xl-10 col-xxl-11"
     >
-      <OrderView class="pt-2" :transOrder="order"></OrderView>
-    </section>
-    <section
-      class="text-end col-11 col-sm-11 col-md-10 col-lg-11 col-xl-10 col-xxl-11 pb-5 my-0 mx-auto"
-    >
-      <div v-if="order.is_paid" class="col-lg-7">
-        <router-link to="/user-products" class="border-0">
-          <button type="button" class="btn btn-outline-dark px-4 me-3">
-            繼續逛逛
+      <OrderView class="pt-2 mb-3" :transOrder="order"></OrderView>
+      <section class="col-12 col-lg-2 px-2 ms-auto">
+        <div v-if="order.is_paid" class="col-lg-7">
+          <router-link to="/user-products" class="border-0">
+            <button type="button" class="btn btn-outline-dark px-4 me-3">
+              繼續逛逛
+            </button>
+          </router-link>
+          <router-link to="/order-list" class="border-0 pe-4">
+            <button type="button" class="btn btn-outline-primary px-4">
+              查看訂單
+            </button>
+          </router-link>
+        </div>
+        <div v-else class="col-12">
+          <button
+            @click="toPay"
+            :disabled="isLoading"
+            type="button"
+            class="btn btn-primary w-100"
+          >
+            確認付款
           </button>
-        </router-link>
-        <router-link to="/order-list" class="border-0 pe-4">
-          <button type="button" class="btn btn-outline-primary px-4">
-            查看訂單
-          </button>
-        </router-link>
-      </div>
-
-      <div v-else class="col-lg-7 pe-3">
-        <button
-          @click="toPay"
-          :disabled="isLoading"
-          type="button"
-          class="btn btn-danger px-4"
-        >
-          確認付款
-        </button>
-      </div>
+        </div>
+      </section>
     </section>
   </main>
 </template>

--- a/src/views/frontend/UserOrder.vue
+++ b/src/views/frontend/UserOrder.vue
@@ -5,20 +5,23 @@
       class="mx-2 mt-5 mx-auto col-11 col-sm-11 col-md-10 col-lg-11 col-xl-10 col-xxl-11"
     >
       <OrderView class="pt-2 mb-3" :transOrder="order"></OrderView>
-      <section class="col-12 col-lg-2 px-2 ms-auto">
-        <div v-if="order.is_paid" class="col-lg-7">
-          <router-link to="/user-products" class="border-0">
-            <button type="button" class="btn btn-outline-dark px-4 me-3">
+      <section class="col-12 col-lg-5 px-2 ms-auto">
+        <div
+          v-if="order.is_paid"
+          class="col-12 d-flex flex-wrap justify-content-between"
+        >
+          <router-link to="/user-products" class="border-0 col p-1">
+            <button type="button" class="w-100 btnBody btn btn-outline-primary">
               繼續逛逛
             </button>
           </router-link>
-          <router-link to="/order-list" class="border-0 pe-4">
-            <button type="button" class="btn btn-outline-primary px-4">
+          <router-link to="/order-list" class="border-0 col p-1">
+            <button type="button" class="w-100 btnBody btn btn-outline-dark">
               查看訂單
             </button>
           </router-link>
         </div>
-        <div v-else class="col-12">
+        <div v-else class="">
           <button
             @click="toPay"
             :disabled="isLoading"
@@ -82,3 +85,9 @@ export default {
   },
 };
 </script>
+
+<style lang="scss" scoped>
+.btnBody {
+  min-width: 100px;
+}
+</style>

--- a/src/views/frontend/UserOrder.vue
+++ b/src/views/frontend/UserOrder.vue
@@ -4,7 +4,7 @@
     <section
       class="mx-2 mt-5 mx-auto col-11 col-sm-11 col-md-10 col-lg-11 col-xl-10 col-xxl-11"
     >
-      <OrderView class="pt-2 mb-3" :transOrder="order"></OrderView>
+      <OrderView class="pt-2 mb-3" :transOrder="order" />
       <section class="col-12 col-lg-5 px-2 ms-auto">
         <div
           v-if="order.is_paid"

--- a/src/views/frontend/UserOrderList.vue
+++ b/src/views/frontend/UserOrderList.vue
@@ -31,7 +31,7 @@
             class="accordion-collapse collapse show"
           >
             <div class="accordion-body pt-4">
-              <OrderView :oneOrder="item" class="mb-3"></OrderView>
+              <OrderView :oneOrder="item" class="mb-3" />
               <div class="col-12 col-lg-3 col-xxl-2 ms-auto text-end px-3">
                 <button
                   v-if="!item.is_paid"

--- a/src/views/frontend/UserOrderList.vue
+++ b/src/views/frontend/UserOrderList.vue
@@ -31,12 +31,12 @@
             class="accordion-collapse collapse show"
           >
             <div class="accordion-body pt-4">
-              <OrderView :oneOrder="item"></OrderView>
-              <div class="text-end col-lg-7 pe-4">
+              <OrderView :oneOrder="item" class="mb-3"></OrderView>
+              <div class="col-12 col-lg-3 col-xxl-2 ms-auto text-end px-3">
                 <button
                   v-if="!item.is_paid"
                   @click="toPay(item.id)"
-                  class="btn btn-danger"
+                  class="w-100 btn btn-primary"
                   type="button"
                 >
                   確認付款

--- a/src/views/frontend/UserProducts.vue
+++ b/src/views/frontend/UserProducts.vue
@@ -404,7 +404,6 @@ export default {
       this.$http
         .post(api, { data: addItem })
         .then((res) => {
-          console.log(res);
           if (res.data.success) {
             this.$pushMsg.status200(res, "已加入購物車");
             this.getCart();


### PR DESCRIPTION
### 設計師建議：
1. 訂單明細的排版不太好閱讀，建議可以參考下圖重新安排佈局
![羽衣甘藍](https://github.com/user-attachments/assets/d8bfd1ed-33c5-4196-99fa-e3b992188bb4)
![Lumina Brew 馬克杯](https://github.com/user-attachments/assets/60c5d0d9-114f-460f-847c-c6bbb7ef7fa4)

2. 目前「訂單日期與訂單編號」有和訂單列表對齊，但是「訂單明細」、「付款資訊」和「確認付款」卻沒有，導致頁面看起來有些凌亂，建議讓「訂單明細」與訂單列表靠左對齊，「付款資訊」、「確認付款」與訂單列表靠右對齊，這樣整體內容寬度會比較一致，視覺上也會更整齊
![訂單明細](https://github.com/user-attachments/assets/3edb0677-e605-4d8d-8878-d1cbb9f963a2)

3. 這邊的重要資訊應為「小計」，建議將強調色用於小計上，單價使用灰階即可（結帳表單也有相同問題，可一併調整）
![150q‡5盒](https://github.com/user-attachments/assets/281d4c88-4605-4881-8c2f-c7300980307f)

4. 紅色帶有警告、危險的意味，除了特價、清空購物車等特殊情況，不建議大量使用。以下圖為例，太頻繁使用紅色反而造成視覺疲勞，無法一眼看出重點，建議除了未付款可使用紅色外，其他都用主色、強調色或灰階處理即可
![訂單明細](https://github.com/user-attachments/assets/7116ce29-3106-4326-a8ea-cf7fd0409893)

5. 目前閱讀動線有些不順暢，使用者依序閱讀完訂單明細、收件人資訊的內容後，又要回到中間才能點選付款按鈕，這邊建議將 CTA 置於畫面右下方，會比較符合使用與閱讀習慣（可參考下圖範例）
![打單明網](https://github.com/user-attachments/assets/6b3c4df4-c522-4497-92d3-803809b66d28)
![17537644344834531270_2024-08-02T05-47-37Z](https://github.com/user-attachments/assets/2af94834-8f90-41ac-af72-004ef31ea1d2)

6. 以電商網站來說，建議以「繼續逛逛」作為主要 CTA 來引導使用者繼續購物
7.  一樣需要注意主色對比度與視覺權重，目前次要按鈕看起來比主要按鈕更顯眼
![小計](https://github.com/user-attachments/assets/9268feb6-d9e5-482f-afbd-a18994210825)

### 修改後：

**1. 訂單內容排版不同寬度的呈現**

![CleanShot 2024-08-19 at 09 54 26@2x](https://github.com/user-attachments/assets/5af39ec1-a146-4a66-b688-8633a4e618e5)
![CleanShot 2024-08-19 at 09 56 20@2x](https://github.com/user-attachments/assets/d9f13ba8-b19d-41b4-8332-e2cb12b5af87)
![CleanShot 2024-08-19 at 09 57 56@2x](https://github.com/user-attachments/assets/2f721c51-ae86-4f03-9d76-146126dc468b)

**2. 『訂單明細』靠左對齊，『訂單日期及編號』、『付款資訊』靠右對齊，確認付款按鈕改到畫面右下方**

![CleanShot 2024-08-19 at 10 08 14@2x](https://github.com/user-attachments/assets/29138827-f340-48f6-899a-4dea2179c60e)

**3. 『繼續逛逛』使用主色、『查看訂單』使用黑色**

![CleanShot 2024-08-19 at 10 17 36@2x](https://github.com/user-attachments/assets/1f45ac7b-b7d7-4f20-97b8-37d57a2dd158)
