### PR TITLE
Update navbar

### DIFF
--- a/src/components/backend/AdminNavbar.vue
+++ b/src/components/backend/AdminNavbar.vue
@@ -4,7 +4,7 @@
       class="col-12 px-3 d-flex justify-content-between align-items-center flex-wrap"
     >
       <router-link to="/" class="navbar-brand text-center m-0">
-        <span class="logoText text-center px-1 fs-3">FRESH BOX</span>
+        <span class="logoText text-center px-3 fs-3">FRESH BOX</span>
       </router-link>
       <div
         ref="adminMenu"
@@ -32,7 +32,7 @@
             aria-label="Close"
           ></button>
         </div>
-        <div class="offcanvas-body">
+        <div class="offcanvas-body px-3">
           <ul class="navbar-nav flex-grow-1">
             <li class="nav-item rounded-0">
               <router-link
@@ -98,7 +98,7 @@
             v-model="productSearchText"
             class="form-control"
             type="search"
-            placeholder="Search for products"
+            placeholder="搜尋產品名稱"
             aria-label="Search"
           />
           <input
@@ -106,7 +106,7 @@
             v-model="orderSearchText"
             class="form-control"
             type="search"
-            placeholder="Search for name on orders"
+            placeholder="搜尋訂單者姓名"
             aria-label="Search"
           />
         </form>

--- a/src/components/backend/AdminNavbar.vue
+++ b/src/components/backend/AdminNavbar.vue
@@ -86,14 +86,13 @@
         class="col-auto d-flex justify-conten-end align-items-center ms-auto"
       >
         <form
-          class="col-auto d-flex align-items-center"
+          class="col-auto d-flex align-items-center searchContainer"
           role="search"
-          :class="{ mobileBox: currentWidth < 992 }"
         >
           <input
             v-if="$route.path === '/dashboard/order-list'"
             v-model="orderSearchText"
-            class="form-control searchInput"
+            class="d-none d-lg-block form-control searchInput"
             type="search"
             placeholder="搜尋訂單者姓名"
             aria-label="Search"
@@ -101,14 +100,46 @@
           <input
             v-else
             v-model="productSearchText"
-            class="form-control searchInput"
+            class="d-none d-lg-block form-control searchInput"
             type="search"
             placeholder="搜尋產品名稱"
             aria-label="Search"
           />
           <button
             type="btn"
-            class="searchBtn btn btn-outline-light bi bi-search fs-4 searchBtn border border-0"
+            class="d-none d-lg-block btn btn-outline-light bi bi-search fs-4 searchBtn border border-0"
+          ></button>
+        </form>
+        <form class="col-auto d-flex align-items-center" role="search">
+          <div
+            id="mobile-admin"
+            class="mobileInputBox px-3 offcanvas offcanvas-top align-items-center justify-content-center"
+          >
+            <input
+              v-if="$route.path === '/dashboard/order-list'"
+              v-model="orderSearchText"
+              class="d-block d-lg-none form-control"
+              type="search"
+              placeholder="搜尋訂單者姓名"
+              aria-label="Search"
+            />
+            <input
+              v-else
+              v-model="productSearchText"
+              class="d-block d-lg-none form-control"
+              type="search"
+              placeholder="搜尋產品名稱"
+              aria-label="Search"
+            />
+          </div>
+
+          <button
+            type="btn"
+            data-bs-toggle="offcanvas"
+            data-bs-target="#mobile-admin"
+            aria-controls="mobile-admin"
+            aria-label="Toggle mobile-admin"
+            class="d-block d-lg-none mobileSearchBtn btn bi bi-search fs-4 border border-0"
           ></button>
         </form>
         <button
@@ -282,7 +313,8 @@ export default {
 .logoText:hover,
 .nav-link:hover,
 .bi-list:hover,
-.searchBtn:hover {
+.searchBtn:hover,
+.mobileSearchBtn:hover {
   color: black;
 }
 
@@ -313,35 +345,18 @@ export default {
   border-color: #f8f9fa;
 }
 
-form:hover .searchInput {
+.searchContainer:hover .searchInput {
   width: 200px;
   padding: 10px 16px;
   transition: 1s;
   border: 1px solid #dee2e6;
 }
 
-.mobileBox:hover {
-  width: 100%;
-  position: absolute;
-  z-index: 1;
-  left: 0px;
-  background-color: #f8f9fa;
+.mobileInputBox {
+  height: 10%;
 }
 
-.mobileBox:hover .searchInput {
-  transition: 2s;
-  width: 95%;
-  position: absolute;
-  right: 2.5%;
-}
-
-.mobileBox:hover .searchBtn {
-  margin-right: 3%;
-  z-index: 2;
-  margin-left: auto;
-  background-color: #fff;
-  padding-top: 0px;
-  padding-bottom: 0px;
-  margin-top: 6px;
+.mobileSearchBtn {
+  color: #000000a6;
 }
 </style>

--- a/src/components/backend/AdminNavbar.vue
+++ b/src/components/backend/AdminNavbar.vue
@@ -17,6 +17,7 @@
       >
         <div class="offcanvas-header px-4">
           <router-link
+            @click="() => closeMenu()"
             to="/"
             class="offcanvas-title logoText text-decoration-none fs-3 px-2"
             id="offcanvasNavbarLabel"
@@ -24,6 +25,7 @@
             FRESH BOX
           </router-link>
           <button
+            @click="() => closeMenu()"
             type="button"
             class="btn-close"
             data-bs-dismiss="offcanvas"
@@ -34,6 +36,7 @@
           <ul class="navbar-nav flex-grow-1">
             <li class="nav-item rounded-0">
               <router-link
+                @click="() => closeMenu()"
                 to="/dashboard/admin's-products"
                 class="nav-link px-3"
                 :class="{
@@ -46,6 +49,7 @@
             </li>
             <li class="nav-item rounded-0">
               <router-link
+                @click="() => closeMenu()"
                 to="/dashboard/coupons"
                 class="nav-link px-3"
                 :class="{
@@ -57,6 +61,7 @@
             </li>
             <li class="nav-item rounded-0">
               <router-link
+                @click="() => closeMenu()"
                 to="/dashboard/order-list"
                 class="nav-link px-3"
                 :class="{
@@ -68,6 +73,7 @@
             </li>
             <li class="nav-item rounded-0">
               <router-link
+                @click="() => closeMenu()"
                 to="/dashboard/admin-QA"
                 class="nav-link px-3"
                 :class="{
@@ -172,7 +178,11 @@ export default {
     },
   },
   methods: {
+    closeMenu() {
+      this.adminNavbar.hide();
+    },
     logOut() {
+      this.closeMenu();
       const api = `${process.env.VUE_APP_API}logout`;
       this.$http
         .post(api)

--- a/src/components/backend/AdminNavbar.vue
+++ b/src/components/backend/AdminNavbar.vue
@@ -86,24 +86,24 @@
         class="col-auto d-flex justify-conten-end align-items-center ms-auto"
       >
         <form
-          class="col-auto d-flex"
+          class="col-auto d-flex align-items-center"
           role="search"
           :class="{ mobileBox: currentWidth < 992 }"
         >
-          <input
-            v-if="$route.path === `/dashboard/admin's-products`"
-            v-model="productSearchText"
-            class="form-control searchInput"
-            type="search"
-            placeholder="搜尋產品名稱"
-            aria-label="Search"
-          />
           <input
             v-if="$route.path === '/dashboard/order-list'"
             v-model="orderSearchText"
             class="form-control searchInput"
             type="search"
             placeholder="搜尋訂單者姓名"
+            aria-label="Search"
+          />
+          <input
+            v-else
+            v-model="productSearchText"
+            class="form-control searchInput"
+            type="search"
+            placeholder="搜尋產品名稱"
             aria-label="Search"
           />
           <button

--- a/src/components/backend/AdminNavbar.vue
+++ b/src/components/backend/AdminNavbar.vue
@@ -38,11 +38,8 @@
               <router-link
                 @click="() => closeMenu()"
                 to="/dashboard/admin's-products"
-                class="nav-link px-3 rounded-0"
-                :class="{
-                  isCurrentNavbarItem:
-                    $route.path === `/dashboard/admin's-products`,
-                }"
+                class="nav-link px-3 rounded"
+                :class="isCurrentPage(`/dashboard/admin's-products`)"
               >
                 產品清單
               </router-link>
@@ -51,10 +48,8 @@
               <router-link
                 @click="() => closeMenu()"
                 to="/dashboard/coupons"
-                class="nav-link px-3"
-                :class="{
-                  isCurrentNavbarItem: $route.path === '/dashboard/coupons',
-                }"
+                class="nav-link px-3 rounded"
+                :class="isCurrentPage('/dashboard/coupons')"
               >
                 優惠券
               </router-link>
@@ -63,10 +58,8 @@
               <router-link
                 @click="() => closeMenu()"
                 to="/dashboard/order-list"
-                class="nav-link px-3"
-                :class="{
-                  isCurrentNavbarItem: $route.path === '/dashboard/order-list',
-                }"
+                class="nav-link px-3 rounded"
+                :class="isCurrentPage('/dashboard/order-list')"
               >
                 訂單
               </router-link>
@@ -75,10 +68,8 @@
               <router-link
                 @click="() => closeMenu()"
                 to="/dashboard/admin-QA"
-                class="nav-link px-3"
-                :class="{
-                  isCurrentNavbarItem: $route.path === '/dashboard/admin-QA',
-                }"
+                class="nav-link px-3 rounded"
+                :class="isCurrentPage('/dashboard/admin-QA')"
               >
                 常見問題
               </router-link>
@@ -178,6 +169,16 @@ export default {
     },
   },
   methods: {
+    isCurrentPage(path) {
+      let className = "";
+      if (this.$route.path === path && this.currentWidth < 992) {
+        className = "isCurrentNavbarItem mobileBg";
+      }
+      if (this.$route.path === path && this.currentWidth >= 992) {
+        className = "isCurrentNavbarItem";
+      }
+      return className;
+    },
     closeMenu() {
       this.adminNavbar.hide();
     },
@@ -264,7 +265,7 @@ export default {
 
 <style lang="scss" scoped>
 * {
-  border: 1px solid;
+  // border: 1px solid;
 }
 .logoText {
   color: #000000a6;
@@ -287,6 +288,10 @@ export default {
 }
 
 .isMobileItem:hover {
-  background-color: #e8e8e8;
+  background-color: #f1f1f1;
+}
+
+.mobileBg {
+  background-color: #f1f1f1;
 }
 </style>

--- a/src/components/backend/AdminNavbar.vue
+++ b/src/components/backend/AdminNavbar.vue
@@ -34,11 +34,11 @@
         </div>
         <div class="offcanvas-body px-3">
           <ul class="navbar-nav flex-grow-1">
-            <li class="nav-item rounded-0">
+            <li class="nav-item rounded" :class="isMoileOrPc">
               <router-link
                 @click="() => closeMenu()"
                 to="/dashboard/admin's-products"
-                class="nav-link px-3"
+                class="nav-link px-3 rounded-0"
                 :class="{
                   isCurrentNavbarItem:
                     $route.path === `/dashboard/admin's-products`,
@@ -47,7 +47,7 @@
                 產品清單
               </router-link>
             </li>
-            <li class="nav-item rounded-0">
+            <li class="nav-item rounded" :class="isMoileOrPc">
               <router-link
                 @click="() => closeMenu()"
                 to="/dashboard/coupons"
@@ -59,7 +59,7 @@
                 優惠券
               </router-link>
             </li>
-            <li class="nav-item rounded-0">
+            <li class="nav-item rounded" :class="isMoileOrPc">
               <router-link
                 @click="() => closeMenu()"
                 to="/dashboard/order-list"
@@ -71,7 +71,7 @@
                 訂單
               </router-link>
             </li>
-            <li class="nav-item rounded-0">
+            <li class="nav-item rounded" :class="isMoileOrPc">
               <router-link
                 @click="() => closeMenu()"
                 to="/dashboard/admin-QA"
@@ -83,7 +83,7 @@
                 常見問題
               </router-link>
             </li>
-            <li class="nav-item rounded-0">
+            <li class="nav-item rounded" :class="isMoileOrPc">
               <a @click.prevent="logOut" class="nav-link px-3" href="#">
                 登出
               </a>
@@ -239,6 +239,15 @@ export default {
       this.currentWidth = window.innerWidth;
     },
   },
+  computed: {
+    isMoileOrPc() {
+      if (this.currentWidth < 992) {
+        return "isMobileItem";
+      } else {
+        return "";
+      }
+    },
+  },
   created() {
     this.getOrders();
 
@@ -275,5 +284,9 @@ export default {
 .isCurrentNavbarItem {
   color: black;
   font-weight: bold;
+}
+
+.isMobileItem:hover {
+  background-color: #e8e8e8;
 }
 </style>

--- a/src/components/backend/AdminNavbar.vue
+++ b/src/components/backend/AdminNavbar.vue
@@ -101,7 +101,7 @@
           <input
             v-if="$route.path === '/dashboard/order-list'"
             v-model="orderSearchText"
-            class="form-control"
+            class="form-control searchInput"
             type="search"
             placeholder="搜尋訂單者姓名"
             aria-label="Search"
@@ -341,6 +341,7 @@ form:hover .searchInput {
   margin-left: auto;
   background-color: #fff;
   padding-top: 0px;
+  padding-bottom: 0px;
   margin-top: 6px;
 }
 </style>

--- a/src/components/backend/AdminNavbar.vue
+++ b/src/components/backend/AdminNavbar.vue
@@ -82,12 +82,18 @@
           </ul>
         </div>
       </div>
-      <div class="d-flex justify-conten-end">
-        <form class="col" role="search">
+      <div
+        class="col-auto d-flex justify-conten-end align-items-center ms-auto"
+      >
+        <form
+          class="col-auto d-flex"
+          role="search"
+          :class="{ mobileBox: currentWidth < 992 }"
+        >
           <input
             v-if="$route.path === `/dashboard/admin's-products`"
             v-model="productSearchText"
-            class="form-control"
+            class="form-control searchInput"
             type="search"
             placeholder="搜尋產品名稱"
             aria-label="Search"
@@ -100,6 +106,10 @@
             placeholder="搜尋訂單者姓名"
             aria-label="Search"
           />
+          <button
+            type="btn"
+            class="searchBtn btn btn-outline-light bi bi-search fs-4 searchBtn border border-0"
+          ></button>
         </form>
         <button
           class="navbar-toggler border-0"
@@ -264,9 +274,6 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-* {
-  // border: 1px solid;
-}
 .logoText {
   color: #000000a6;
   font-family: "Times New Roman", Times, serif;
@@ -274,7 +281,8 @@ export default {
 
 .logoText:hover,
 .nav-link:hover,
-.bi-list:hover {
+.bi-list:hover,
+.searchBtn:hover {
   color: black;
 }
 
@@ -293,5 +301,46 @@ export default {
 
 .mobileBg {
   background-color: #f1f1f1;
+}
+
+.searchBtn {
+  color: #000000a6;
+}
+
+.searchInput {
+  width: 0px;
+  padding: 10px 0px;
+  border-color: #f8f9fa;
+}
+
+form:hover .searchInput {
+  width: 200px;
+  padding: 10px 16px;
+  transition: 1s;
+  border: 1px solid #dee2e6;
+}
+
+.mobileBox:hover {
+  width: 100%;
+  position: absolute;
+  z-index: 1;
+  left: 0px;
+  background-color: #f8f9fa;
+}
+
+.mobileBox:hover .searchInput {
+  transition: 2s;
+  width: 95%;
+  position: absolute;
+  right: 2.5%;
+}
+
+.mobileBox:hover .searchBtn {
+  margin-right: 3%;
+  z-index: 2;
+  margin-left: auto;
+  background-color: #fff;
+  padding-top: 0px;
+  margin-top: 6px;
 }
 </style>

--- a/src/components/backend/AdminNavbar.vue
+++ b/src/components/backend/AdminNavbar.vue
@@ -92,7 +92,7 @@
           <input
             v-if="$route.path === '/dashboard/order-list'"
             v-model="orderSearchText"
-            class="d-none d-lg-block form-control searchInput"
+            class="d-none d-sm-block form-control searchInput"
             type="search"
             placeholder="搜尋訂單者姓名"
             aria-label="Search"
@@ -100,14 +100,14 @@
           <input
             v-else
             v-model="productSearchText"
-            class="d-none d-lg-block form-control searchInput"
+            class="d-none d-sm-block form-control searchInput"
             type="search"
             placeholder="搜尋產品名稱"
             aria-label="Search"
           />
           <button
             type="btn"
-            class="d-none d-lg-block btn btn-outline-light bi bi-search fs-4 searchBtn border border-0"
+            class="d-none d-sm-block btn btn-outline-light bi bi-search fs-4 searchBtn border border-0"
           ></button>
         </form>
         <form class="col-auto d-flex align-items-center" role="search">
@@ -118,7 +118,7 @@
             <input
               v-if="$route.path === '/dashboard/order-list'"
               v-model="orderSearchText"
-              class="d-block d-lg-none form-control"
+              class="d-block d-sm-none form-control"
               type="search"
               placeholder="搜尋訂單者姓名"
               aria-label="Search"
@@ -126,7 +126,7 @@
             <input
               v-else
               v-model="productSearchText"
-              class="d-block d-lg-none form-control"
+              class="d-block d-sm-none form-control"
               type="search"
               placeholder="搜尋產品名稱"
               aria-label="Search"
@@ -139,7 +139,7 @@
             data-bs-target="#mobile-admin"
             aria-controls="mobile-admin"
             aria-label="Toggle mobile-admin"
-            class="d-block d-lg-none mobileSearchBtn btn bi bi-search fs-4 border border-0"
+            class="d-block d-sm-none mobileSearchBtn btn bi bi-search fs-4 border border-0"
           ></button>
         </form>
         <button

--- a/src/components/backend/AdminNavbar.vue
+++ b/src/components/backend/AdminNavbar.vue
@@ -3,26 +3,22 @@
     <div
       class="col-12 px-3 d-flex justify-content-between align-items-center flex-wrap"
     >
-      <button
-        class="navbar-toggler border-0 col-auto"
-        type="button"
-        data-bs-toggle="offcanvas"
-        data-bs-target="#offcanvasNavbar"
-        aria-controls="offcanvasNavbar"
-        aria-label="Toggle navigation"
-      >
-        <i class="bi bi-list fs-2 px-2"></i>
-      </button>
+      <router-link to="/" class="navbar-brand text-center m-0">
+        <span class="logoText text-center px-1 fs-3">FRESH BOX</span>
+      </router-link>
       <div
-        class="offcanvas offcanvas-start w-50"
+        ref="adminMenu"
+        class="offcanvas offcanvas-end"
+        id="admin_offcanvasNavbar"
+        aria-labelledby="admin_offcanvasNavbarLabel"
+        data-bs-backdrop="true"
+        data-bs-scroll="true"
         tabindex="-1"
-        id="offcanvasNavbar"
-        aria-labelledby="offcanvasNavbarLabel"
       >
         <div class="offcanvas-header px-4">
           <router-link
             to="/"
-            class="offcanvas-title logoText text-decoration-none"
+            class="offcanvas-title logoText text-decoration-none fs-3 px-2"
             id="offcanvasNavbarLabel"
           >
             FRESH BOX
@@ -34,12 +30,12 @@
             aria-label="Close"
           ></button>
         </div>
-        <div class="offcanvas-body ps-5">
-          <ul class="navbar-nav flex-grow-1 pe-3">
-            <li class="nav-item">
+        <div class="offcanvas-body">
+          <ul class="navbar-nav flex-grow-1">
+            <li class="nav-item rounded-0">
               <router-link
                 to="/dashboard/admin's-products"
-                class="nav-link"
+                class="nav-link px-3"
                 :class="{
                   isCurrentNavbarItem:
                     $route.path === `/dashboard/admin's-products`,
@@ -48,10 +44,10 @@
                 產品清單
               </router-link>
             </li>
-            <li class="nav-item">
+            <li class="nav-item rounded-0">
               <router-link
                 to="/dashboard/coupons"
-                class="nav-link"
+                class="nav-link px-3"
                 :class="{
                   isCurrentNavbarItem: $route.path === '/dashboard/coupons',
                 }"
@@ -59,10 +55,10 @@
                 優惠券
               </router-link>
             </li>
-            <li class="nav-item">
+            <li class="nav-item rounded-0">
               <router-link
                 to="/dashboard/order-list"
-                class="nav-link"
+                class="nav-link px-3"
                 :class="{
                   isCurrentNavbarItem: $route.path === '/dashboard/order-list',
                 }"
@@ -70,10 +66,10 @@
                 訂單
               </router-link>
             </li>
-            <li class="nav-item">
+            <li class="nav-item rounded-0">
               <router-link
                 to="/dashboard/admin-QA"
-                class="nav-link"
+                class="nav-link px-3"
                 :class="{
                   isCurrentNavbarItem: $route.path === '/dashboard/admin-QA',
                 }"
@@ -81,37 +77,44 @@
                 常見問題
               </router-link>
             </li>
-            <li class="nav-item">
-              <a @click.prevent="logOut" class="nav-link" href="#"> 登出 </a>
+            <li class="nav-item rounded-0">
+              <a @click.prevent="logOut" class="nav-link px-3" href="#">
+                登出
+              </a>
             </li>
           </ul>
         </div>
       </div>
-      <router-link
-        v-if="currentWidth > 275"
-        to="/"
-        class="logoTextLink navbar-brand text-center p-0 m-0"
-      >
-        <span class="logoText text-center">FRESH BOX</span>
-      </router-link>
-      <form class="col-2 col-sm-3" role="search">
-        <input
-          v-if="$route.path === `/dashboard/admin's-products`"
-          v-model="productSearchText"
-          class="form-control"
-          type="search"
-          placeholder="Search for products"
-          aria-label="Search"
-        />
-        <input
-          v-if="$route.path === '/dashboard/order-list'"
-          v-model="orderSearchText"
-          class="form-control"
-          type="search"
-          placeholder="Search for name on orders"
-          aria-label="Search"
-        />
-      </form>
+      <div class="d-flex justify-conten-end">
+        <form class="col" role="search">
+          <input
+            v-if="$route.path === `/dashboard/admin's-products`"
+            v-model="productSearchText"
+            class="form-control"
+            type="search"
+            placeholder="Search for products"
+            aria-label="Search"
+          />
+          <input
+            v-if="$route.path === '/dashboard/order-list'"
+            v-model="orderSearchText"
+            class="form-control"
+            type="search"
+            placeholder="Search for name on orders"
+            aria-label="Search"
+          />
+        </form>
+        <button
+          class="navbar-toggler border-0"
+          type="button"
+          data-bs-toggle="offcanvas"
+          data-bs-target="#admin_offcanvasNavbar"
+          aria-controls="admin_offcanvasNavbar"
+          aria-label="Toggle navigation"
+        >
+          <i class="bi bi-list fs-2 px-1"></i>
+        </button>
+      </div>
     </div>
   </nav>
 </template>
@@ -235,24 +238,16 @@ export default {
     }, 500);
   },
   mounted() {
-    const offcanvasElementList = document.querySelectorAll(".offcanvas");
-    this.adminNavbar = [...offcanvasElementList].map(
-      (offcanvasEl) => new Offcanvas(offcanvasEl)
-    );
+    this.adminNavbar = new Offcanvas(this.$refs.adminMenu, { toggle: false });
   },
 };
 </script>
 
 <style lang="scss" scoped>
-.logoTextLink {
-  width: 1px;
-  position: absolute;
-  right: 50%;
-  display: flex;
-  justify-content: center;
+* {
+  border: 1px solid;
 }
 .logoText {
-  width: fit-content;
   color: #000000a6;
   font-family: "Times New Roman", Times, serif;
 }

--- a/src/components/backend/AdminNavbar.vue
+++ b/src/components/backend/AdminNavbar.vue
@@ -115,22 +115,29 @@
             id="mobile-admin"
             class="mobileInputBox px-3 offcanvas offcanvas-top align-items-center justify-content-center"
           >
-            <input
+            <div
               v-if="$route.path === '/dashboard/order-list'"
-              v-model="orderSearchText"
-              class="d-block d-sm-none form-control"
-              type="search"
-              placeholder="搜尋訂單者姓名"
-              aria-label="Search"
-            />
-            <input
-              v-else
-              v-model="productSearchText"
-              class="d-block d-sm-none form-control"
-              type="search"
-              placeholder="搜尋產品名稱"
-              aria-label="Search"
-            />
+              class="d-block d-sm-none w-100 mobileInputWrap"
+            >
+              <input
+                v-model="orderSearchText"
+                class="form-control mobileInput"
+                type="search"
+                placeholder="搜尋訂單者姓名"
+                aria-label="Search"
+              />
+              <i class="bi bi-search mobileSearchIcon"></i>
+            </div>
+            <div v-else class="d-block d-sm-none w-100 mobileInputWrap">
+              <input
+                v-model="productSearchText"
+                class="form-control mobileInput"
+                type="search"
+                placeholder="搜尋產品名稱"
+                aria-label="Search"
+              />
+              <i class="bi bi-search mobileSearchIcon"></i>
+            </div>
           </div>
 
           <button
@@ -358,5 +365,19 @@ export default {
 
 .mobileSearchBtn {
   color: #000000a6;
+}
+
+.mobileInput {
+  padding-left: 33px;
+}
+
+.mobileInputWrap {
+  position: relative;
+}
+
+.mobileSearchIcon {
+  position: absolute;
+  bottom: 7px;
+  left: 10px;
 }
 </style>

--- a/src/components/frontend/UserNavbar.vue
+++ b/src/components/frontend/UserNavbar.vue
@@ -4,9 +4,9 @@
       class="d-flex justify-content-between align-items-center flex-wrap col-12 px-3"
     >
       <router-link to="/" class="logoTextLink navbar-brand text-center m-0">
-        <span class="logoText text-center text-primary px-1 fs-3"
-          >FRESH BOX</span
-        >
+        <span class="logoText text-center text-primary px-1 fs-3">
+          FRESH BOX
+        </span>
       </router-link>
       <div
         ref="menu"
@@ -36,56 +36,42 @@
         </div>
         <div class="offcanvas-body" :class="currentWidth < 992 ? '' : 'px-4'">
           <ul class="navbar-nav flex-grow-1">
-            <li
-              class="nav-item rounded"
-              :class="{ mobile: currentWidth < 992 }"
-            >
+            <li class="nav-item rounded p-0" :class="isMoileOrPc">
               <router-link
                 @click="goToUserProducts"
                 to="/user-products"
-                class="nav-link text-primary"
-                :class="{
-                  isCurrentNavbarItem: currentPath === '/user-products',
-                }"
+                class="nav-link text-primary py-2 px-3 rounded"
+                :class="isCurrentPage('/user-products')"
               >
                 所有產品
               </router-link>
             </li>
-            <li
-              class="nav-item rounded"
-              :class="{ mobile: currentWidth < 992 }"
-            >
+            <li class="nav-item rounded p-0" :class="isMoileOrPc">
               <router-link
                 @click="() => closeMenu()"
                 to="/favorite"
-                :class="{ isCurrentNavbarItem: currentPath === '/favorite' }"
-                class="nav-link text-primary"
+                class="nav-link text-primary py-2 px-3 rounded"
+                :class="isCurrentPage('/favorite')"
               >
                 收藏
               </router-link>
             </li>
-            <li
-              class="nav-item rounded"
-              :class="{ mobile: currentWidth < 992 }"
-            >
+            <li class="nav-item rounded p-0" :class="isMoileOrPc">
               <router-link
                 @click="() => closeMenu()"
                 to="/order-list"
-                :class="{ isCurrentNavbarItem: currentPath === '/order-list' }"
-                class="nav-link text-primary"
+                class="nav-link text-primary py-2 px-3 rounded"
+                :class="isCurrentPage('/order-list')"
               >
                 訂單
               </router-link>
             </li>
-            <li
-              class="nav-item rounded"
-              :class="{ mobile: currentWidth < 992 }"
-            >
+            <li class="nav-item rounded p-0" :class="isMoileOrPc">
               <router-link
                 @click="() => closeMenu()"
                 to="/QA"
-                :class="{ isCurrentNavbarItem: currentPath === '/QA' }"
-                class="nav-link text-primary"
+                class="nav-link text-primary py-2 px-3 rounded"
+                :class="isCurrentPage('/QA')"
               >
                 常見問題
               </router-link>
@@ -161,7 +147,6 @@ export default {
       carts: [],
       orders: [],
       orderPage: 1,
-      searchInput: false,
       open: false,
       currentWidth: "1000",
     };
@@ -209,12 +194,21 @@ export default {
     },
   },
   methods: {
+    isCurrentPage(path) {
+      let className = "";
+      if (this.currentPath === path && this.currentWidth < 992) {
+        className = "isCurrentNavbarItem mobileBg";
+      }
+      if (this.currentPath === path && this.currentWidth >= 992) {
+        className = "isCurrentNavbarItem";
+      }
+      return className;
+    },
     closeMenu() {
       this.userNavbar.hide();
     },
     openSearchBar() {
       this.open = !this.open;
-      console.log(this.open);
       setTimeout(() => {
         this.open = !this.open;
       }, 10000);
@@ -267,7 +261,15 @@ export default {
       this.currentWidth = window.innerWidth;
     },
   },
-  computed: {},
+  computed: {
+    isMoileOrPc() {
+      if (this.currentWidth < 992) {
+        return "isMobileItem";
+      } else {
+        return "";
+      }
+    },
+  },
   created() {
     this.getCurrentWidth();
     this.getOrders();
@@ -287,10 +289,6 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-* {
-  // border: 1px solid;
-}
-
 .logoText {
   width: fit-content;
   font-family: "Times New Roman", Times, serif;
@@ -331,11 +329,12 @@ export default {
   color: #f9c406;
 }
 
-.mobile {
-  padding: 0px 15px;
+.isMobileItem {
+  color: #f9c406 !important;
 }
 
-.mobile:hover {
+.isMobileItem:hover,
+.mobileBg {
   background-color: #333;
 }
 </style>

--- a/src/components/frontend/UserNavbar.vue
+++ b/src/components/frontend/UserNavbar.vue
@@ -1,20 +1,15 @@
 <template>
   <nav class="navbar navbar-expand-lg bg-black fixed-top">
     <div
-      class="col-12 px-3 d-flex justify-content-between align-items-center flex-wrap"
+      class="d-flex justify-content-between align-items-center flex-wrap col-12 px-3"
     >
-      <button
-        class="navbar-toggler border-0 col-auto"
-        type="button"
-        data-bs-toggle="offcanvas"
-        data-bs-target="#offcanvasNavbar"
-        aria-controls="offcanvasNavbar"
-        aria-label="Toggle navigation"
-      >
-        <i class="bi bi-list fs-2 px-2 text-primary"></i>
-      </button>
+      <router-link to="/" class="logoTextLink navbar-brand text-center m-0">
+        <span class="logoText text-center text-primary px-1 fs-3"
+          >FRESH BOX</span
+        >
+      </router-link>
       <div
-        class="offcanvas offcanvas-start bg-black w-50"
+        class="offcanvas offcanvas-end bg-black"
         tabindex="-1"
         id="offcanvasNavbar"
         aria-labelledby="offcanvasNavbarLabel"
@@ -22,7 +17,7 @@
         <div class="offcanvas-header px-4">
           <router-link
             to="/"
-            class="offcanvas-title logoText text-decoration-none"
+            class="offcanvas-title logoText text-decoration-none fs-3"
             id="offcanvasNavbarLabel"
           >
             FRESH BOX
@@ -76,80 +71,56 @@
               </router-link>
             </li>
           </ul>
-          <form class="col-lg-3 col-xl-4 col-xxl-3" role="search">
-            <input
-              v-if="currentPath === '/order-list'"
-              v-model="orderSearchText"
-              class="form-control"
-              type="search"
-              placeholder="Search for name on orders"
-              aria-label="Search"
-            />
-            <input
-              v-else
-              v-model="productSearchText"
-              class="form-control col-1"
-              type="search"
-              placeholder="Search for product name"
-              aria-label="Search"
-            />
-          </form>
         </div>
       </div>
+      <div class="d-flex justify-content-end align-items-center col">
+        <section class="d-flex align-items-center searchContainer">
+          <input
+            v-if="currentPath === '/order-list'"
+            v-model="orderSearchText"
+            type="search"
+            class="form-control searchText"
+            placeholder="搜尋訂單者姓名"
+            aria-label="Search"
+          />
+          <input
+            v-else
+            v-model="productSearchText"
+            type="search"
+            class="form-control searchText"
+            placeholder="搜尋產品名稱"
+            aria-label="Search"
+          />
+          <button
+            type="btn"
+            class="btn btn-outline-primary bi bi-search bg-black fs-4 searchBtn border border-0"
+          ></button>
+        </section>
 
-      <router-link to="/" class="logoTextLink navbar-brand text-center p-0 m-0">
-        <span class="logoText text-center text-primary fs-3">FRESH BOX</span>
-      </router-link>
-
-      <router-link to="/cart" class="nav-link d-flex flex-row-reverse">
-        <div
-          style="height: 75px"
-          class="h-100 d-flex flex-column align-items-center text-center d-none d-sm-block d-md-block d-lg-block d-xl-block d-xxl-block"
+        <router-link to="/cart" class="nav-link px-2">
+          <div class="">
+            <div class="h-auto position-relative">
+              <i class="bi bi-cart2 fs-2 text-primary"></i>
+              <span
+                v-if="carts.length >= 1"
+                class="badge rounded-pill numInCart"
+              >
+                {{ carts.length }}
+              </span>
+            </div>
+          </div>
+        </router-link>
+        <button
+          class="navbar-toggler border-0 col-auto m-0"
+          type="button"
+          data-bs-toggle="offcanvas"
+          data-bs-target="#offcanvasNavbar"
+          aria-controls="offcanvasNavbar"
+          aria-label="Toggle navigation"
         >
-          <div class="h-auto position-relative">
-            <i class="bi bi-cart2 fs-2 text-primary"></i>
-            <span
-              v-if="carts.length >= 1"
-              class="sm_cart_num_position translate-middle badge rounded-pill numInCart"
-            >
-              {{ carts.length }}
-              <span class="visually-hidden">cart items</span>
-            </span>
-          </div>
-
-          <h5 class="m-0 d-flex align-items-center">
-            <span class="amountText sm_amountText text-yellow-light badge"
-              >NT$ {{ $filters.currency(undiscountedAmount) }}
-            </span>
-          </h5>
-        </div>
-
-        <div
-          class="h-100 d-flex flex-column align-items-center pe-1 d-block d-sm-none d-md-none d-lg-none d-xl-none d-xxl-none"
-        >
-          <div class="h-auto position-relative">
-            <i class="bi bi-cart2 fs-2 iconLink text-primary"></i>
-            <span
-              v-if="carts.length >= 1"
-              class="xs_cart_num_position translate-middle badge rounded-pill numInCart"
-            >
-              {{ carts.length }}
-              <span class="visually-hidden">cart items</span>
-            </span>
-          </div>
-
-          <div
-            class="m-0 d-flex flex-column justify-content-center align-items-center"
-          >
-            <span class="amountText xs_amountText badge text-yellow-light"
-              >NT$
-            </span>
-            <span class="amountText xs_amountText badge text-yellow-light"
-              >{{ $filters.currency(undiscountedAmount) }}
-            </span>
-          </div>
-        </div>
-      </router-link>
+          <i class="bi bi-list fs-2 px-1 text-primary"></i>
+        </button>
+      </div>
     </div>
   </nav>
 </template>
@@ -170,6 +141,7 @@ export default {
       orders: [],
       orderPage: 1,
       searchInput: false,
+      open: false,
     };
   },
   inject: ["emitter"],
@@ -215,6 +187,13 @@ export default {
     },
   },
   methods: {
+    openSearchBar() {
+      this.open = !this.open;
+      console.log(this.open);
+      setTimeout(() => {
+        this.open = !this.open;
+      }, 10000);
+    },
     getProducts() {
       const api = `${process.env.VUE_APP_API}api/${process.env.VUE_APP_PATH}/products/all`;
       this.$http
@@ -259,15 +238,6 @@ export default {
         });
     },
   },
-  computed: {
-    undiscountedAmount() {
-      let total = 0;
-      this.carts.forEach((item) => {
-        total += item.total;
-      });
-      return total;
-    },
-  },
   created() {
     this.getOrders();
     this.getCart();
@@ -289,49 +259,21 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-.logoTextLink {
-  width: 1px;
-  position: absolute;
-  right: 50%;
-  display: flex;
-  justify-content: center;
+* {
+  border: 1px solid;
 }
+
 .logoText {
   width: fit-content;
   font-family: "Times New Roman", Times, serif;
 }
 
-.iconLink {
-  font-weight: 100;
-  padding: 7px;
-}
-
-.sm_cart_num_position {
-  position: absolute;
-  top: 14px;
-  left: 70px;
-}
-
-.xs_cart_num_position {
-  position: absolute;
-  top: 10px;
-  left: 28px;
-}
-
-.amountText {
-  padding: 5px 0px;
-}
-
-.sm_amountText {
-  width: 120px;
-}
-
-.xs_amountText {
-  width: 60px;
-}
 .numInCart {
   background-color: #f9c406;
   color: #000;
+  position: absolute;
+  top: 2px;
+  right: -10px;
 }
 
 .isCurrentNavbarItem {
@@ -339,7 +281,20 @@ export default {
   color: #f9c406 !important;
 }
 
-.text-primary:hover {
+.text-primary:hover,
+.searchBtn:hover {
   color: #f9c406 !important;
+}
+
+.searchText {
+  width: 0px;
+  padding: 6px 0px;
+  transition: 1.5s;
+  border: 0px;
+}
+
+.searchContainer:hover .searchText {
+  width: 200px;
+  padding: 6px 12px;
 }
 </style>

--- a/src/components/frontend/UserNavbar.vue
+++ b/src/components/frontend/UserNavbar.vue
@@ -13,6 +13,7 @@
         tabindex="-1"
         id="offcanvasNavbar"
         aria-labelledby="offcanvasNavbarLabel"
+        data-bs-backdrop="false"
       >
         <div class="offcanvas-header px-4">
           <router-link

--- a/src/components/frontend/UserNavbar.vue
+++ b/src/components/frontend/UserNavbar.vue
@@ -14,7 +14,8 @@
         tabindex="-1"
         id="offcanvasNavbar"
         aria-labelledby="offcanvasNavbarLabel"
-        data-bs-backdrop="false"
+        data-bs-backdrop="true"
+        data-bs-scroll="true"
       >
         <div class="offcanvas-header px-4">
           <router-link

--- a/src/components/frontend/UserNavbar.vue
+++ b/src/components/frontend/UserNavbar.vue
@@ -103,29 +103,37 @@
           ></button>
         </section>
 
-        <section
-          class="d-block d-lg-none d-flex align-items-center mobileSearchBox"
-        >
-          <input
-            v-if="currentPath === '/order-list'"
-            v-model="orderSearchText"
-            class="border-0 d-block d-lg-none form-control mobileSearchText"
-            type="search"
-            placeholder="搜尋訂單者姓名"
-            aria-label="mobileSearch"
-          />
-          <input
-            v-else
-            v-model="productSearchText"
-            class="border-0 d-block d-lg-none form-control mobileSearchText"
-            type="search"
-            placeholder="搜尋產品名稱"
-            aria-label="mobileSearch"
-          />
+        <section class="d-block d-lg-none d-flex align-items-center">
+          <div
+            class="mobileInputBox px-3 offcanvas offcanvas-top bg-black align-items-center justify-content-center"
+            id="mobile"
+            data-bs-scroll="true"
+            data-bs-backdrop="true"
+            tabindex="-1"
+            aria-labelledby="mobileLabel"
+          >
+            <input
+              v-if="currentPath === '/order-list'"
+              v-model="orderSearchText"
+              class="border-0 d-block d-lg-none form-control"
+              type="search"
+              placeholder="搜尋訂單者姓名"
+            />
 
+            <input
+              v-else
+              v-model="productSearchText"
+              class="border-0 d-block d-lg-none form-control"
+              type="search"
+              placeholder="搜尋產品名稱"
+            />
+          </div>
           <button
             type="btn"
-            class="d-block d-lg-none mobileSearchBtn btn btn-outline-primary bi bi-search bg-black fs-4 searchBtn border border-0"
+            class="d-block d-lg-none btn btn-outline-primary bi bi-search bg-black fs-4 searchBtn border border-0"
+            data-bs-toggle="offcanvas"
+            data-bs-target="#mobile"
+            aria-controls="mobile"
           ></button>
         </section>
 
@@ -160,7 +168,6 @@
 
 <script>
 import Offcanvas from "bootstrap/js/dist/offcanvas";
-
 export default {
   data() {
     return {
@@ -232,12 +239,6 @@ export default {
     },
     closeMenu() {
       this.userNavbar.hide();
-    },
-    openSearchBar() {
-      this.open = !this.open;
-      setTimeout(() => {
-        this.open = !this.open;
-      }, 10000);
     },
     getProducts() {
       const api = `${process.env.VUE_APP_API}api/${process.env.VUE_APP_PATH}/products/all`;
@@ -364,36 +365,7 @@ export default {
   background-color: #333;
 }
 
-.mobileSearchBox {
-  width: 49px;
-  height: 100%;
-  background-color: #000;
-  z-index: 1;
-}
-
-.mobileSearchText {
-  width: 0%;
-  padding: 10px 0px;
-}
-
-.mobileSearchBox:hover .mobileSearchText {
-  width: 95%;
-  transition: 2s;
-  position: absolute;
-  right: 2.5%;
-  padding: 10px 16px 10px 16px;
-}
-
-.mobileSearchBox:hover {
-  position: absolute;
-  width: 100%;
-  left: 0px;
-}
-
-.mobileSearchBox:hover .mobileSearchBtn {
-  position: absolute;
-  right: 3%;
-  background-color: #fff !important;
-  height: 44px;
+.mobileInputBox {
+  height: 10%;
 }
 </style>

--- a/src/components/frontend/UserNavbar.vue
+++ b/src/components/frontend/UserNavbar.vue
@@ -3,7 +3,7 @@
     <div
       class="d-flex justify-content-between align-items-center flex-wrap col-12 px-3"
     >
-      <router-link to="/" class="logoTextLink navbar-brand text-center m-0">
+      <router-link to="/" class="navbar-brand text-center m-0">
         <span class="logoText text-center text-primary px-1 fs-3">
           FRESH BOX
         </span>

--- a/src/components/frontend/UserNavbar.vue
+++ b/src/components/frontend/UserNavbar.vue
@@ -85,7 +85,7 @@
             v-if="currentPath === '/order-list'"
             v-model="orderSearchText"
             type="search"
-            class="d-none d-lg-block form-control searchText"
+            class="d-none d-sm-block form-control searchText"
             placeholder="搜尋訂單者姓名"
             aria-label="Search"
           />
@@ -93,17 +93,17 @@
             v-else
             v-model="productSearchText"
             type="search"
-            class="d-none d-lg-block form-control searchText"
+            class="d-none d-sm-block form-control searchText"
             placeholder="搜尋產品名稱"
             aria-label="PCSearch"
           />
           <button
             type="btn"
-            class="d-none d-lg-block btn btn-outline-primary bi bi-search bg-black fs-4 searchBtn border border-0"
+            class="d-none d-sm-block btn btn-outline-primary bi bi-search bg-black fs-4 searchBtn border border-0"
           ></button>
         </section>
 
-        <section class="d-block d-lg-none d-flex align-items-center">
+        <section class="d-block d-sm-none d-flex align-items-center">
           <div
             class="mobileInputBox px-3 offcanvas offcanvas-top bg-black align-items-center justify-content-center"
             id="mobile"
@@ -115,7 +115,7 @@
             <input
               v-if="currentPath === '/order-list'"
               v-model="orderSearchText"
-              class="border-0 d-block d-lg-none form-control"
+              class="border-0 d-block d-sm-none form-control"
               type="search"
               placeholder="搜尋訂單者姓名"
             />
@@ -123,14 +123,14 @@
             <input
               v-else
               v-model="productSearchText"
-              class="border-0 d-block d-lg-none form-control"
+              class="border-0 d-block d-sm-none form-control"
               type="search"
               placeholder="搜尋產品名稱"
             />
           </div>
           <button
             type="btn"
-            class="d-block d-lg-none btn btn-outline-primary bi bi-search bg-black fs-4 searchBtn border border-0"
+            class="d-block d-sm-none btn btn-outline-primary bi bi-search bg-black fs-4 searchBtn border border-0"
             data-bs-toggle="offcanvas"
             data-bs-target="#mobile"
             aria-controls="mobile"

--- a/src/components/frontend/UserNavbar.vue
+++ b/src/components/frontend/UserNavbar.vue
@@ -21,7 +21,7 @@
           <router-link
             @click="() => closeMenu()"
             to="/"
-            class="offcanvas-title logoText text-decoration-none fs-3"
+            class="ps-2 offcanvas-title logoText text-decoration-none fs-3 text-primary"
             id="offcanvasNavbarLabel"
           >
             FRESH BOX
@@ -34,9 +34,12 @@
             aria-label="Close"
           ></button>
         </div>
-        <div class="offcanvas-body px-4">
-          <ul class="navbar-nav flex-grow-1 pe-3">
-            <li class="nav-item">
+        <div class="offcanvas-body" :class="currentWidth < 992 ? '' : 'px-4'">
+          <ul class="navbar-nav flex-grow-1">
+            <li
+              class="nav-item rounded"
+              :class="{ mobile: currentWidth < 992 }"
+            >
               <router-link
                 @click="goToUserProducts"
                 to="/user-products"
@@ -48,7 +51,10 @@
                 所有產品
               </router-link>
             </li>
-            <li class="nav-item">
+            <li
+              class="nav-item rounded"
+              :class="{ mobile: currentWidth < 992 }"
+            >
               <router-link
                 @click="() => closeMenu()"
                 to="/favorite"
@@ -58,7 +64,10 @@
                 收藏
               </router-link>
             </li>
-            <li class="nav-item">
+            <li
+              class="nav-item rounded"
+              :class="{ mobile: currentWidth < 992 }"
+            >
               <router-link
                 @click="() => closeMenu()"
                 to="/order-list"
@@ -68,7 +77,10 @@
                 訂單
               </router-link>
             </li>
-            <li class="nav-item">
+            <li
+              class="nav-item rounded"
+              :class="{ mobile: currentWidth < 992 }"
+            >
               <router-link
                 @click="() => closeMenu()"
                 to="/QA"
@@ -151,6 +163,7 @@ export default {
       orderPage: 1,
       searchInput: false,
       open: false,
+      currentWidth: "1000",
     };
   },
   inject: ["emitter"],
@@ -250,8 +263,13 @@ export default {
           this.$pushMsg.status404(error.response.data.message);
         });
     },
+    getCurrentWidth() {
+      this.currentWidth = window.innerWidth;
+    },
   },
+  computed: {},
   created() {
+    this.getCurrentWidth();
     this.getOrders();
     this.getCart();
     this.getProducts();
@@ -270,7 +288,7 @@ export default {
 
 <style lang="scss" scoped>
 * {
-  border: 1px solid;
+  // border: 1px solid;
 }
 
 .logoText {
@@ -311,5 +329,13 @@ export default {
 .btn-outline-primary:hover {
   background-color: #000;
   color: #f9c406;
+}
+
+.mobile {
+  padding: 0px 15px;
+}
+
+.mobile:hover {
+  background-color: #333;
 }
 </style>

--- a/src/components/frontend/UserNavbar.vue
+++ b/src/components/frontend/UserNavbar.vue
@@ -85,7 +85,7 @@
             v-if="currentPath === '/order-list'"
             v-model="orderSearchText"
             type="search"
-            class="form-control searchText"
+            class="d-none d-lg-block form-control searchText"
             placeholder="搜尋訂單者姓名"
             aria-label="Search"
           />
@@ -93,13 +93,39 @@
             v-else
             v-model="productSearchText"
             type="search"
-            class="form-control searchText"
+            class="d-none d-lg-block form-control searchText"
             placeholder="搜尋產品名稱"
-            aria-label="Search"
+            aria-label="PCSearch"
           />
           <button
             type="btn"
-            class="btn btn-outline-primary bi bi-search bg-black fs-4 searchBtn border border-0"
+            class="d-none d-lg-block btn btn-outline-primary bi bi-search bg-black fs-4 searchBtn border border-0"
+          ></button>
+        </section>
+
+        <section
+          class="d-block d-lg-none d-flex align-items-center mobileSearchBox"
+        >
+          <input
+            v-if="currentPath === '/order-list'"
+            v-model="orderSearchText"
+            class="border-0 d-block d-lg-none form-control mobileSearchText"
+            type="search"
+            placeholder="搜尋訂單者姓名"
+            aria-label="mobileSearch"
+          />
+          <input
+            v-else
+            v-model="productSearchText"
+            class="border-0 d-block d-lg-none form-control mobileSearchText"
+            type="search"
+            placeholder="搜尋產品名稱"
+            aria-label="mobileSearch"
+          />
+
+          <button
+            type="btn"
+            class="d-block d-lg-none mobileSearchBtn btn btn-outline-primary bi bi-search bg-black fs-4 searchBtn border border-0"
           ></button>
         </section>
 
@@ -336,5 +362,38 @@ export default {
 .isMobileItem:hover,
 .mobileBg {
   background-color: #333;
+}
+
+.mobileSearchBox {
+  width: 49px;
+  height: 100%;
+  background-color: #000;
+  z-index: 1;
+}
+
+.mobileSearchText {
+  width: 0%;
+  padding: 10px 0px;
+}
+
+.mobileSearchBox:hover .mobileSearchText {
+  width: 95%;
+  transition: 2s;
+  position: absolute;
+  right: 2.5%;
+  padding: 10px 16px 10px 16px;
+}
+
+.mobileSearchBox:hover {
+  position: absolute;
+  width: 100%;
+  left: 0px;
+}
+
+.mobileSearchBox:hover .mobileSearchBtn {
+  position: absolute;
+  right: 3%;
+  background-color: #fff !important;
+  height: 44px;
 }
 </style>

--- a/src/components/frontend/UserNavbar.vue
+++ b/src/components/frontend/UserNavbar.vue
@@ -112,21 +112,27 @@
             tabindex="-1"
             aria-labelledby="mobileLabel"
           >
-            <input
+            <div
               v-if="currentPath === '/order-list'"
-              v-model="orderSearchText"
-              class="border-0 d-block d-sm-none form-control"
-              type="search"
-              placeholder="搜尋訂單者姓名"
-            />
-
-            <input
-              v-else
-              v-model="productSearchText"
-              class="border-0 d-block d-sm-none form-control"
-              type="search"
-              placeholder="搜尋產品名稱"
-            />
+              class="d-block d-sm-none w-100 mobileInputWrap"
+            >
+              <input
+                v-model="orderSearchText"
+                class="border-0 form-control mobileInput"
+                type="search"
+                placeholder="搜尋訂單者姓名"
+              />
+              <i class="bi bi-search mobileSearchIcon"></i>
+            </div>
+            <div v-else class="d-block d-sm-none w-100 mobileInputWrap">
+              <input
+                v-model="productSearchText"
+                class="border-0 form-control mobileInput"
+                type="search"
+                placeholder="搜尋產品名稱"
+              />
+              <i class="bi bi-search mobileSearchIcon"></i>
+            </div>
           </div>
           <button
             type="btn"
@@ -367,5 +373,19 @@ export default {
 
 .mobileInputBox {
   height: 10%;
+}
+
+.mobileInput {
+  padding-left: 33px;
+}
+
+.mobileInputWrap {
+  position: relative;
+}
+
+.mobileSearchIcon {
+  position: absolute;
+  bottom: 7px;
+  left: 10px;
 }
 </style>

--- a/src/components/frontend/UserNavbar.vue
+++ b/src/components/frontend/UserNavbar.vue
@@ -29,7 +29,7 @@
           <button
             @click="() => closeMenu()"
             type="button"
-            class="btn-close btn-close-white"
+            class="bi bi-x-lg btn btn-outline-primary border-0 btn-lg"
             data-bs-dismiss="offcanvas"
             aria-label="Close"
           ></button>
@@ -306,5 +306,10 @@ export default {
 .searchContainer:hover .searchText {
   width: 200px;
   padding: 6px 12px;
+}
+
+.btn-outline-primary:hover {
+  background-color: #000;
+  color: #f9c406;
 }
 </style>

--- a/src/components/frontend/UserNavbar.vue
+++ b/src/components/frontend/UserNavbar.vue
@@ -9,6 +9,7 @@
         >
       </router-link>
       <div
+        ref="menu"
         class="offcanvas offcanvas-end bg-black"
         tabindex="-1"
         id="offcanvasNavbar"
@@ -17,6 +18,7 @@
       >
         <div class="offcanvas-header px-4">
           <router-link
+            @click="() => closeMenu()"
             to="/"
             class="offcanvas-title logoText text-decoration-none fs-3"
             id="offcanvasNavbarLabel"
@@ -24,6 +26,7 @@
             FRESH BOX
           </router-link>
           <button
+            @click="() => closeMenu()"
             type="button"
             class="btn-close btn-close-white"
             data-bs-dismiss="offcanvas"
@@ -46,6 +49,7 @@
             </li>
             <li class="nav-item">
               <router-link
+                @click="() => closeMenu()"
                 to="/favorite"
                 :class="{ isCurrentNavbarItem: currentPath === '/favorite' }"
                 class="nav-link text-primary"
@@ -55,6 +59,7 @@
             </li>
             <li class="nav-item">
               <router-link
+                @click="() => closeMenu()"
                 to="/order-list"
                 :class="{ isCurrentNavbarItem: currentPath === '/order-list' }"
                 class="nav-link text-primary"
@@ -64,6 +69,7 @@
             </li>
             <li class="nav-item">
               <router-link
+                @click="() => closeMenu()"
                 to="/QA"
                 :class="{ isCurrentNavbarItem: currentPath === '/QA' }"
                 class="nav-link text-primary"
@@ -112,6 +118,7 @@
           </div>
         </router-link>
         <button
+          @click="close"
           class="navbar-toggler border-0 col-auto m-0"
           type="button"
           data-bs-toggle="offcanvas"
@@ -188,6 +195,9 @@ export default {
     },
   },
   methods: {
+    closeMenu() {
+      this.userNavbar.hide();
+    },
     openSearchBar() {
       this.open = !this.open;
       console.log(this.open);
@@ -219,6 +229,7 @@ export default {
     },
     goToUserProducts() {
       this.emitter.emit("goToUserProducts");
+      this.closeMenu();
     },
     getOrders() {
       const api = `${process.env.VUE_APP_API}api/${process.env.VUE_APP_PATH}/orders?page=${this.orderPage}`;
@@ -251,10 +262,7 @@ export default {
     });
   },
   mounted() {
-    const offcanvasElementList = document.querySelectorAll(".offcanvas");
-    this.userNavbar = [...offcanvasElementList].map(
-      (offcanvasEl) => new Offcanvas(offcanvasEl)
-    );
+    this.userNavbar = new Offcanvas(this.$refs.menu, { toggle: false });
   },
 };
 </script>


### PR DESCRIPTION
### 設計師建議
- 目前只有 Search Bar 的 Placeholder 使用英文，建議統一語系（都使用中文或是英文）
- 一般使用者的閱讀習慣是由左到右、由上到下，目前 Navbar 的資訊排列順序會讓閱讀動線有點卡頓，建議可以將順序調整為：Logo、分頁連結、Search Bar、購物車 icon
![FRESII BOX](https://github.com/user-attachments/assets/2bf2fcc6-86e8-4127-82de-923ebe5fb383)
-  建議購物車 icon 可以不用顯示金額，避免在手機版撐高整體高度導致不易閱讀
![FRESH BOX](https://github.com/user-attachments/assets/8cca958d-103a-4ed5-8042-10e788783336)

**行動版｜**

-  點擊漢堡選單裡的分頁連結後，建議自動收合選單
-  Search Bar 建議置於最上方，且 Placeholder 建議完整顯示
-  分頁連結的 Active 狀態可以再更明顯一些，可以嘗試再加上底色（參考下圖效果），因為漢堡選單本身為黑底，這邊建議底色可以使用深灰色

![FRESH BOX](https://github.com/user-attachments/assets/5c69c0b6-07c3-428b-8ae4-f2947337edb8)
![va Desion yotem](https://github.com/user-attachments/assets/8414bae9-f4ec-4cf2-945a-3d2f5a0abfa5)


### 已修改如下：
### **User**

- 點擊漢堡選單裡的分頁連結後，可自動收合選單

- 將順序調整為：Logo、分頁連結、Search Bar、購物車 icon，購物車 icon 不顯示金額

![CleanShot 2024-08-29 at 15 12 01](https://github.com/user-attachments/assets/0bbab42e-df05-4f04-80f9-5b1322d7b87d)

- Search Bar 置於最上方，滑鼠碰到 search icon 搜尋欄位才會出現 ，且 Placeholder 可完整顯示

![CleanShot 2024-08-29 at 15 16 01](https://github.com/user-attachments/assets/3eb2890c-8d47-413e-8bdb-5d8af4b741f8)

- 行動版 navbar  介面

![CleanShot 2024-08-29 at 15 20 39](https://github.com/user-attachments/assets/d286ebe3-71a8-421e-a112-fd52823c7e8f)

- 行動版分頁連結的 Active 狀態加上底色：深灰色

![CleanShot 2024-08-29 at 15 22 46](https://github.com/user-attachments/assets/819a5d00-1b17-44f9-89ff-1b4aa04c9748)

-  行動版在寬度575px (含) 以下時，點擊 search icon 後，搜尋欄位改由頂端出現

![CleanShot 2024-08-29 at 15 31 30](https://github.com/user-attachments/assets/93574880-73b2-4bb4-a710-4175375700f4)

### **Admin**
- 點擊漢堡選單裡的分頁連結後，可自動收合選單
- 將順序調整為：Logo、分頁連結、Search Bar

![CleanShot 2024-08-29 at 15 35 52](https://github.com/user-attachments/assets/5062b388-48da-4e4f-a657-5e93e335123a)

- Search Bar 置於最上方，滑鼠碰到 search icon 搜尋欄位才會出現 ，且 Placeholder 可完整顯示

![CleanShot 2024-08-29 at 15 39 25](https://github.com/user-attachments/assets/26f1735b-cf96-448d-afa8-4678b77cd562)

- 行動版 navbar  介面

![CleanShot 2024-08-29 at 15 41 39](https://github.com/user-attachments/assets/2238ef61-2a8f-4a27-9bba-0e3b9d39c780)

- 行動版分頁連結的 Active 狀態加上底色：淺灰色

![CleanShot 2024-08-29 at 15 42 51](https://github.com/user-attachments/assets/d62825cb-eaf9-45cd-845e-17a5decad976)

-  行動版在寬度575px (含) 以下時，點擊 search icon 後，搜尋欄位改由頂端出現

![CleanShot 2024-08-29 at 15 43 51](https://github.com/user-attachments/assets/79a77c8f-9ea2-492a-a6ad-c38ffd7c2141)
