### PR TITLE
Card hover and btn style

### DIFF
--- a/src/components/frontend/SwiperImgs.vue
+++ b/src/components/frontend/SwiperImgs.vue
@@ -2,7 +2,7 @@
   <div>
     <Swiper
       style="padding: 0px 35px"
-      class="d-flex align-items-center"
+      class="d-flex align-items-center m-0"
       :modules="modules"
       :slides-per-view="5"
       :space-between="40"
@@ -33,10 +33,6 @@
         '1200': {
           slidesPerView: 4,
           spaceBetween: 45,
-        },
-        '1400': {
-          slidesPerView: 5,
-          spaceBetween: 50,
         },
       }"
       @swiper="onSwiper"
@@ -246,6 +242,16 @@ a {
 :root .swiper-button-next,
 .swiper-button-prev {
   --swiper-navigation-size: 20px;
+}
+
+.swiper-button-next {
+  position: absolute;
+  right: 0px;
+}
+
+.swiper-button-prev {
+  position: absolute;
+  left: 0px;
 }
 
 :root .swiper-button-next:hover,

--- a/src/components/frontend/SwiperImgs.vue
+++ b/src/components/frontend/SwiperImgs.vue
@@ -43,52 +43,63 @@
       @slideChange="onSlideChange"
     >
       <SwiperSlide v-for="item in allProducts" :key="item.id">
-        <router-link
-          @click="goToProductPage"
-          :to="`/product/${item.id}`"
-          class="linkStyle"
-        >
+        <div @click="goToProductPage(item.id)" class="productItem rounded my-3">
           <img
-            class="img-fluid carouselImg"
+            class="img-fluid carouselImg rounded-top"
             :src="item.imageUrl"
             alt="carouselImg"
           />
-        </router-link>
-        <div>
-          <div :class="{ 'fs-6 fw-bold': currentWidth < 600 }" class="p-2 fs-5">
-            {{ item.title }}
-          </div>
-          <div :class="{ 'smStyle fw-light': currentWidth < 600 }" class="px-2">
-            {{ item.content }}
-          </div>
-          <div
-            :class="{ 'smStyle fw-light': currentWidth < 600 }"
-            class="priceContainer d-flex p-2 flex-wrap align-items-center"
-          >
+          <div>
             <div
-              class="text-secondary col-12"
-              :class="{
-                'text-decoration-line-through':
-                  item.price !== item.origin_price,
-              }"
+              class="p-2 fs-5 text-black"
+              :class="{ 'fs-6 fw-bold': currentWidth < 600 }"
             >
-              NT$ {{ $filters.currency(item.origin_price) }}
+              {{ item.title }}
             </div>
-            <strong
-              v-if="item.price !== item.origin_price"
-              class="text-danger col-12"
+            <div
+              class="px-2 text-black"
+              :class="{ 'smStyle fw-light': currentWidth < 600 }"
             >
-              NT$ {{ $filters.currency(item.price) }}
-            </strong>
+              {{ item.content }}
+            </div>
+            <div
+              :class="{ 'smStyle fw-light': currentWidth < 600 }"
+              class="priceContainer d-flex p-2 flex-wrap align-items-center"
+            >
+              <div
+                class="text-secondary col-12"
+                :class="{
+                  'text-decoration-line-through':
+                    item.price !== item.origin_price,
+                }"
+              >
+                NT$ {{ $filters.currency(item.origin_price) }}
+              </div>
+              <strong
+                v-if="item.price !== item.origin_price"
+                class="text-danger col-12"
+              >
+                NT$ {{ $filters.currency(item.price) }}
+              </strong>
+            </div>
+            <div class="text-center pb-2">
+              <button
+                @click.stop="addCart(item)"
+                :class="{ 'btn-sm': currentWidth < 600 }"
+                class="mb-0 btn btn-light addBtn"
+                type="button"
+              >
+                <div
+                  v-if="item.id === status.addLoadingItem"
+                  class="spinner-border text-light spinner-grow-sm"
+                  role="status"
+                >
+                  <span class="visually-hidden">Loading...</span>
+                </div>
+                <p v-else class="mb-0">加入購物車</p>
+              </button>
+            </div>
           </div>
-          <button
-            @click="addCart(item)"
-            :class="{ 'btn-sm': currentWidth < 600 }"
-            class="w-100 mb-0 btn btn-light rounded-0"
-            type="button"
-          >
-            加入購物車
-          </button>
         </div>
       </SwiperSlide>
       <div class="swiper-button-prev text-dark"></div>
@@ -114,6 +125,10 @@ export default {
     return {
       allProducts: [],
       currentWidth: "1000",
+      status: {
+        addLoadingItem: "",
+        delLoadingItem: "",
+      },
     };
   },
   components: {
@@ -147,6 +162,7 @@ export default {
     addCart(item) {
       const addItem = { product_id: item.id, qty: 1 };
       const api = `${process.env.VUE_APP_API}api/${process.env.VUE_APP_PATH}/cart`;
+      this.status.addLoadingItem = item.id;
       this.$http
         .post(api, { data: addItem })
         .then((res) => {
@@ -159,12 +175,17 @@ export default {
         })
         .catch((error) => {
           this.$pushMsg.status404(error.response.data.message);
+        })
+        .finally(() => {
+          this.status.addLoadingItem = "";
         });
     },
     isCurrentWidth() {
       this.currentWidth = window.innerWidth;
     },
-    goToProductPage() {
+    goToProductPage(id) {
+      console.log(id);
+      this.$router.push(`/product/${id}`);
       if (this.$route.path !== "/") {
         setTimeout(() => {
           location.reload();
@@ -180,14 +201,38 @@ export default {
 };
 </script>
 <style lang="scss" scoped>
+a {
+  text-decoration: none;
+}
+
+.productItem {
+  height: auto;
+}
+
+.productItem .addBtn {
+  width: 100%;
+}
+
+.productItem:hover {
+  cursor: pointer;
+  box-shadow: 0px 0px 7px 0px #8f8f8f;
+}
+
+.productItem:hover .addBtn {
+  width: 90%;
+  background-color: #ccaf3c;
+  border: 1px solid #ccaf3c;
+}
+
+.productItem .addBtn:hover {
+  background-color: #d4bb59;
+  border: 1px solid #d1b750;
+}
+
 .carouselImg {
   width: 100%;
   height: 150px;
   object-fit: cover;
-}
-
-.carouselImg:hover {
-  box-shadow: 0px 8px 10px rgba(36, 35, 35, 0.511) !important;
 }
 
 .smStyle {

--- a/src/views/frontend/ProductDetails.vue
+++ b/src/views/frontend/ProductDetails.vue
@@ -157,8 +157,8 @@
           </section>
         </div>
       </div>
-      <h3 class="mb-4 pb-3 pt-5 col-10 border-bottom">推薦商品</h3>
-      <SwiperImgs class="col-lg-10" />
+      <h3 class="mb-4 pb-3 pt-5 col-11 col-md-10 border-bottom">推薦商品</h3>
+      <SwiperImgs class="col-11 col-md-10 px-0" />
     </div>
   </div>
 </template>

--- a/src/views/frontend/UserProducts.vue
+++ b/src/views/frontend/UserProducts.vue
@@ -70,7 +70,7 @@
           class="col-12 col-sm-6 col-lg-4 col-xxl-3"
           :class="{ 'ps-4': currentWidth >= 576 }"
         >
-          <div class="card mx-auto mb-4">
+          <div @click="goToProduct(item)" class="card mx-auto mb-4">
             <h3
               v-if="isMyFavorite(item)"
               @click="delMyFavorite(item)"
@@ -83,11 +83,7 @@
               class="bi bi-suit-heart myFavoriteIcon position-absolute z-1"
             ></h3>
             <div class="position-relative">
-              <img
-                @click="goToProduct(item)"
-                :src="item.imageUrl"
-                class="imgBody card-img-top"
-              />
+              <img :src="item.imageUrl" class="imgBody card-img-top" />
             </div>
 
             <div class="card-body d-flex flex-column justify-content-between">
@@ -572,9 +568,13 @@ img {
   height: 6vh;
 }
 
-.imgBody:hover {
+.card:hover {
   cursor: pointer;
-  border: 2px solid #fff;
+  background-color: #f8f9fa;
+}
+
+.card:hover .imgBody {
+  border: 2px solid #f8f9fa;
 }
 
 .badge {

--- a/src/views/frontend/UserProducts.vue
+++ b/src/views/frontend/UserProducts.vue
@@ -73,13 +73,13 @@
           <div @click="goToProduct(item)" class="card mx-auto mb-4">
             <h3
               v-if="isMyFavorite(item)"
-              @click="delMyFavorite(item)"
+              @click.stop="delMyFavorite(item)"
               class="bi bi-suit-heart-fill delmyFavoriteIcon position-absolute z-1"
             ></h3>
 
             <h3
               v-else
-              @click="addMyFavorite(item)"
+              @click.stop="addMyFavorite(item)"
               class="bi bi-suit-heart myFavoriteIcon position-absolute z-1"
             ></h3>
             <div class="position-relative">
@@ -167,7 +167,7 @@
                 aria-label="Default button group"
               >
                 <button
-                  @click="delOne(item)"
+                  @click.stop="delOne(item)"
                   :disabled="!item.buyQty || item.id === status.delLoadingItem"
                   type="button"
                   class="btn btn-light w-50"
@@ -183,7 +183,7 @@
                 </button>
 
                 <button
-                  @click="addCart(item)"
+                  @click.stop="addCart(item)"
                   :disabled="item.id === status.addLoadingItem"
                   type="button"
                   class="btn btn-light w-50"

--- a/src/views/frontend/UserProducts.vue
+++ b/src/views/frontend/UserProducts.vue
@@ -580,11 +580,11 @@ img {
 }
 
 .xs_title_text {
-  font-size: 14px;
+  font-size: 16px;
 }
 
 .xs_text {
-  font-size: 12px;
+  font-size: 14px;
 }
 
 .noMore {

--- a/src/views/frontend/UserProducts.vue
+++ b/src/views/frontend/UserProducts.vue
@@ -160,44 +160,21 @@
                   </strong>
                 </div>
               </div>
-
-              <div
-                class="btn-group w-100"
-                role="group"
-                aria-label="Default button group"
+              <button
+                @click.stop="addCart(item)"
+                :disabled="item.id === status.addLoadingItem"
+                type="button"
+                class="btn btn-light addBtn"
               >
-                <button
-                  @click.stop="delOne(item)"
-                  :disabled="!item.buyQty || item.id === status.delLoadingItem"
-                  type="button"
-                  class="btn btn-light w-50"
+                <div
+                  v-if="item.id === status.addLoadingItem"
+                  class="spinner-border text-light spinner-grow-sm"
+                  role="status"
                 >
-                  <div
-                    v-if="item.id === status.delLoadingItem"
-                    class="spinner-border text-dark spinner-grow-sm"
-                    role="status"
-                  >
-                    <span class="visually-hidden">Loading...</span>
-                  </div>
-                  <i v-else class="bi bi-dash-lg"></i>
-                </button>
-
-                <button
-                  @click.stop="addCart(item)"
-                  :disabled="item.id === status.addLoadingItem"
-                  type="button"
-                  class="btn btn-light w-50"
-                >
-                  <div
-                    v-if="item.id === status.addLoadingItem"
-                    class="spinner-border text-dark spinner-grow-sm"
-                    role="status"
-                  >
-                    <span class="visually-hidden">Loading...</span>
-                  </div>
-                  <i v-else class="bi bi-plus-lg"></i>
-                </button>
-              </div>
+                  <span class="visually-hidden">Loading...</span>
+                </div>
+                <p v-else class="mb-0">加入購物車</p>
+              </button>
             </div>
           </div>
         </section>
@@ -451,47 +428,6 @@ export default {
           this.status.addLoadingItem = "";
         });
     },
-    delOne(item) {
-      const updateQty = item.buyQty - 1;
-      const delItem = { product_id: item.id, qty: updateQty };
-      const api = `${process.env.VUE_APP_API}api/${process.env.VUE_APP_PATH}/cart/${item.pushCartId}`;
-      this.status.delLoadingItem = item.id;
-      this.$http
-        .put(api, { data: delItem })
-        .then((res) => {
-          if (res.data.success) {
-            this.$pushMsg.status200(res, "已刪除 1 個品項");
-            if (res.data.data.qty === 0) {
-              this.delItem(item.pushCartId);
-            }
-            this.getCart();
-            this.emitter.emit("updateProductInCart");
-          } else {
-            this.$pushMsg.status200(res, "刪除失敗");
-          }
-        })
-        .catch((error) => {
-          this.$pushMsg.status404(error.response.data.message);
-        })
-        .finally(() => {
-          this.status.delLoadingItem = "";
-        });
-    },
-    delItem(id) {
-      const api = `${process.env.VUE_APP_API}api/${process.env.VUE_APP_PATH}/cart/${id}`;
-      this.$http
-        .delete(api)
-        .then((res) => {
-          if (this.searchText === "") {
-            location.reload();
-          }
-
-          return res;
-        })
-        .catch((error) => {
-          this.$pushMsg.status404(error.response.data.message);
-        });
-    },
     goToProduct(item) {
       this.$router.push(`/product/${item.id}`);
     },
@@ -570,11 +506,8 @@ img {
 
 .card:hover {
   cursor: pointer;
-  background-color: #f8f9fa;
-}
-
-.card:hover .imgBody {
-  border: 2px solid #f8f9fa;
+  border: none;
+  box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.15);
 }
 
 .badge {
@@ -692,5 +625,11 @@ img {
 
 .miniWidth {
   padding-top: 29px;
+}
+
+.addBtn:hover {
+  background-color: #ccaf3c;
+  border: 1px solid #ccaf3c;
+  color: #000;
 }
 </style>

--- a/src/views/frontend/UserProducts.vue
+++ b/src/views/frontend/UserProducts.vue
@@ -57,11 +57,18 @@
       </section>
     </div>
     <div class="mx-auto col-11 col-sm-9 col-lg-10 col-xxl-10">
-      <section v-if="noResults" class="mt-4">
+      <section v-if="noResults" class="mt-4 text-center">
         <h3>查無相符商品</h3>
       </section>
-      <section v-if="noFavorites" class="mt-4">
-        <h3>目前無收藏的商品</h3>
+      <section v-if="noFavorites" class="mt-4 text-center">
+        <h3 class="mb-4">目前無收藏的商品</h3>
+        <button
+          @click="goToAllProducts"
+          class="btn btn-outline-primary"
+          type="button"
+        >
+          繼續逛逛
+        </button>
       </section>
       <div class="d-flex flex-wrap col-12">
         <section
@@ -380,6 +387,7 @@ export default {
       this.isLoading = false;
     },
     goToAllProducts() {
+      this.isLoading = true;
       if (this.$route.path === "/user-products") {
         location.reload();
       } else {

--- a/src/views/frontend/UserProducts.vue
+++ b/src/views/frontend/UserProducts.vue
@@ -83,7 +83,7 @@
               class="bi bi-suit-heart myFavoriteIcon position-absolute z-1"
             ></h3>
             <div class="position-relative">
-              <img :src="item.imageUrl" class="imgBody card-img-top" />
+              <img :src="item.imageUrl" class="card-img-top" />
             </div>
 
             <div class="card-body d-flex flex-column justify-content-between">
@@ -507,7 +507,17 @@ img {
 .card:hover {
   cursor: pointer;
   border: none;
-  box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.15);
+  box-shadow: 0px 0px 7px 0px #8f8f8f;
+}
+
+.card:hover .addBtn {
+  background-color: #ccaf3c;
+  border: 1px solid #ccaf3c;
+}
+
+.card .addBtn:hover {
+  background-color: #d4bb59;
+  border: 1px solid #d1b750;
 }
 
 .badge {
@@ -625,11 +635,5 @@ img {
 
 .miniWidth {
   padding-top: 29px;
-}
-
-.addBtn:hover {
-  background-color: #ccaf3c;
-  border: 1px solid #ccaf3c;
-  color: #000;
 }
 </style>


### PR DESCRIPTION
### **設計師建議**
-  產品卡片應該要整張都能點選
-  產品卡片建議可以做出 Hover 的樣式
-  CTA 直接使用「加入購物車」按鈕會更直覺

![CleanShot 2024-09-04 at 11 12 49](https://github.com/user-attachments/assets/163dc287-4367-4416-ba69-b0fe85552213)

-  推薦商品建議一次顯示四張卡片即可，數量太多容易造成認知負擔。
-  另外上下頁切換鍵建議可以離卡片遠一些，目前看起來有些擁擠

![17537644344834531270_2024-08-02T05-49-30Z](https://github.com/user-attachments/assets/50abaf1f-6ae1-49db-b004-f139ac8d8087)

-  Hover 狀態的陰影偏重，建議可以降低顏色透明度並把 Blur 數值拉高一些

![紅蘿蔔](https://github.com/user-attachments/assets/c430c131-fd0a-4636-8a4d-08bcea73eb3c)

-  行動版的產品卡片建議單行顯示會比較好閱讀
-  行動版目前產品卡片的內容字級偏小，建議整體可以調大 2px~4px 左右
-  收藏清單沒有產品時建議加上 CTA 引導使用者前往產品頁購物

![17537644344834531270_2024-08-02T05-48-15Z](https://github.com/user-attachments/assets/e3bfb48b-2016-4e6a-928f-bf2bf9ae697b)

-------------------------------------------------------------------------------------------------------------
- 修改後 - 產品卡片：

![CleanShot 2024-09-04 at 11 14 04](https://github.com/user-attachments/assets/f7e58fa0-226e-4971-aacf-c07f8ab619ed)

- 修改後 - 推薦商品：

![CleanShot 2024-09-04 at 13 13 41](https://github.com/user-attachments/assets/a9c9b7aa-074e-4aa8-a7fc-969eda261f5d)

- 修改後 - 行動版：

![CleanShot 2024-09-04 at 13 29 59](https://github.com/user-attachments/assets/75d1c478-abc2-47da-b1e5-e4f4be62ab01)

- 修改後 - 無收藏商品時：

![CleanShot 2024-09-04 at 13 49 27](https://github.com/user-attachments/assets/bd1c5c9e-534f-4adf-ad03-f01adaf4c749)
