### PR TITLE
Update home view

### DIFF
--- a/src/components/frontend/BestSellers.vue
+++ b/src/components/frontend/BestSellers.vue
@@ -48,22 +48,13 @@
         >
           <img class="bestSellersImg" :src="item.imgUrl" alt="bestSellerImg" />
           <div>
-            <div
-              class="p-2 fs-5 text-black"
-              :class="{ 'fs-6 fw-bold': currentWidth < 600 }"
-            >
+            <div class="p-2 fs-5 fw-bold text-black">
               {{ item.title }}
             </div>
-            <div
-              class="px-2 text-black"
-              :class="{ 'smStyle fw-light': currentWidth < 600 }"
-            >
+            <div class="px-2 text-black">
               {{ item.content }}
             </div>
-            <div
-              class="d-flex p-2 flex-wrap align-items-center"
-              :class="{ 'smStyle fw-light': currentWidth < 600 }"
-            >
+            <div class="d-flex p-2 flex-wrap align-items-center">
               <div
                 class="text-secondary col-12"
                 :class="{
@@ -84,7 +75,6 @@
               <button
                 @click.stop="addCart(item)"
                 class="mb-0 btn btn-light shadow addBtn"
-                :class="{ 'btn-sm': currentWidth < 600 }"
                 type="button"
               >
                 <div
@@ -193,7 +183,6 @@ export default {
           id: "-Ntoe6-WbDJY9ChStYOs",
         },
       ],
-      currentWidth: 1000,
       status: {
         addLoadingItem: "",
         delLoadingItem: "",
@@ -239,12 +228,6 @@ export default {
           this.status.addLoadingItem = "";
         });
     },
-    isCurrentWidth() {
-      this.currentWidth = window.innerWidth;
-    },
-  },
-  created() {
-    this.isCurrentWidth();
   },
 };
 </script>
@@ -252,7 +235,6 @@ export default {
 <style lang="scss" scoped>
 .productItem:hover {
   cursor: pointer;
-  // filter: brightness(1.1);
 }
 .bestSellersImg {
   width: 100%;
@@ -276,10 +258,6 @@ export default {
 .productItem .addBtn:hover {
   background-color: #d4bb59;
   border: 1px solid #d1b750;
-}
-
-.smStyle {
-  font-size: 14px;
 }
 
 :root .swiper-button-next,

--- a/src/components/frontend/BestSellers.vue
+++ b/src/components/frontend/BestSellers.vue
@@ -1,0 +1,304 @@
+<template>
+  <div class="d-flex">
+    <Swiper
+      style="padding: 0px 35px"
+      class="d-flex align-items-center m-0"
+      :modules="modules"
+      :slides-per-view="5"
+      :space-between="40"
+      :grabCursor="true"
+      :navigation="{
+        nextEl: '.swiper-button-next',
+        prevEl: '.swiper-button-prev',
+      }"
+      :pagination="false"
+      :scrollbar="false"
+      :autoplay="{
+        delay: 2500,
+        disableOnInteraction: false,
+      }"
+      :breakpoints="{
+        '0': {
+          slidesPerView: 1,
+          spaceBetween: 45,
+        },
+        '500': {
+          slidesPerView: 2,
+          spaceBetween: 45,
+        },
+        '750': {
+          slidesPerView: 3,
+          spaceBetween: 45,
+        },
+        '900': {
+          slidesPerView: 4,
+          spaceBetween: 30,
+        },
+      }"
+      @swiper="onSwiper"
+      @slideChange="onSlideChange"
+    >
+      <SwiperSlide v-for="(item, index) in bestSellerProducts" :key="item.id">
+        <div
+          data-aos="fade-up"
+          data-aos-duration="800"
+          :data-aos-delay="index * 100"
+          @click="goToProductPage(item.id)"
+          class="productItem my-3"
+        >
+          <img class="bestSellersImg" :src="item.imgUrl" alt="bestSellerImg" />
+          <div>
+            <div
+              class="p-2 fs-5 text-black"
+              :class="{ 'fs-6 fw-bold': currentWidth < 600 }"
+            >
+              {{ item.title }}
+            </div>
+            <div
+              class="px-2 text-black"
+              :class="{ 'smStyle fw-light': currentWidth < 600 }"
+            >
+              {{ item.content }}
+            </div>
+            <div
+              class="d-flex p-2 flex-wrap align-items-center"
+              :class="{ 'smStyle fw-light': currentWidth < 600 }"
+            >
+              <div
+                class="text-secondary col-12"
+                :class="{
+                  'text-decoration-line-through':
+                    item.price !== item.origin_price,
+                }"
+              >
+                NT$ {{ $filters.currency(item.origin_price) }}
+              </div>
+              <strong
+                v-if="item.price !== item.origin_price"
+                class="text-danger col-12"
+              >
+                NT$ {{ $filters.currency(item.price) }}
+              </strong>
+            </div>
+            <div class="text-center pb-2">
+              <button
+                @click.stop="addCart(item)"
+                class="mb-0 btn btn-light shadow addBtn"
+                :class="{ 'btn-sm': currentWidth < 600 }"
+                type="button"
+              >
+                <div
+                  v-if="item.id === status.addLoadingItem"
+                  class="spinner-border text-light spinner-grow-sm"
+                  role="status"
+                >
+                  <span class="visually-hidden">Loading...</span>
+                </div>
+                <p v-else class="mb-0">加入購物車</p>
+              </button>
+            </div>
+          </div>
+        </div>
+      </SwiperSlide>
+      <div class="swiper-button-prev text-dark"></div>
+      <div class="swiper-button-next text-dark"></div>
+    </Swiper>
+    <!-- <div
+      v-for="(item, index) in bestSellerProducts"
+      :key="item.id"
+      class="border pt-4 mb-4 px-3 col-10 col-sm-6 col-md-6 col-lg-3 col-xl-3"
+      data-aos="fade-up"
+      data-aos-duration="800"
+      :data-aos-delay="index * 100"
+    >
+      <router-link :to="`/product/${item.id}`" class="linkStyle">
+        <img
+          class="img-fluid bestSellersImg shadow-lg"
+          :src="item.imgUrl"
+          alt="bestSellerProductImg"
+        />
+      </router-link>
+      <div>
+        <div class="p-2 fs-5">{{ item.title }}</div>
+        <div class="px-2">{{ item.content }}</div>
+        <div class="d-flex p-2 justify-content-between">
+          <div class="text-decoration-line-through text-secondary">
+            NT$ {{ $filters.currency(item.origin_price) }}
+          </div>
+          <div class="text-end">NT$ {{ $filters.currency(item.price) }}</div>
+        </div>
+        <button
+          @click="addCart(item)"
+          class="w-100 my-3 btn btn-light shadow rounded-0"
+          type="button"
+        >
+          加入購物車
+        </button>
+      </div>
+    </div> -->
+  </div>
+</template>
+
+<script>
+import {
+  Navigation,
+  Pagination,
+  Scrollbar,
+  A11y,
+  Autoplay,
+} from "swiper/modules";
+import { Swiper, SwiperSlide } from "swiper/vue";
+import "swiper/css";
+import "swiper/css/navigation";
+import "swiper/css/pagination";
+import "swiper/css/scrollbar";
+export default {
+  data() {
+    return {
+      bestSellerProducts: [
+        {
+          title: "台灣水蜜桃",
+          imgUrl:
+            "https://images.unsplash.com/photo-1595124245030-41448b199d6d?q=80&w=1965&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+          content: "600g±10% / 盒",
+          origin_price: 600,
+          price: 500,
+          id: "-NsfVCnYqjTKonXqR4cO",
+        },
+        {
+          title: "無籽黑葡萄",
+          imgUrl:
+            "https://images.unsplash.com/photo-1601275868399-45bec4f4cd9d?q=80&w=1935&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+          content: "1.8kg±10% / 盒",
+          origin_price: 699,
+          price: 569,
+          id: "-Nsg6Th1g1I7OzbPJF1g",
+        },
+        {
+          title: "空運櫻桃",
+          imgUrl:
+            "https://images.unsplash.com/photo-1595657241488-468423581c23?q=80&w=1974&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+          content: "1kg±10% / 盒",
+          origin_price: 1200,
+          price: 1000,
+          id: "-NsfbLG9v4NLUQwba1YJ",
+        },
+        {
+          title: "蘆筍",
+          imgUrl:
+            "https://images.unsplash.com/photo-1629875235136-737fef945cfd?q=80&w=2070&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+          content: "200g±10% / 盒",
+          origin_price: 150,
+          price: 120,
+          id: "-Ntoe6-WbDJY9ChStYOs",
+        },
+      ],
+      currentWidth: 1000,
+      status: {
+        addLoadingItem: "",
+        delLoadingItem: "",
+      },
+    };
+  },
+  components: {
+    Swiper,
+    SwiperSlide,
+  },
+  setup() {
+    const onSwiper = () => {};
+    const onSlideChange = () => {};
+    return {
+      onSwiper,
+      onSlideChange,
+      modules: [Navigation, Pagination, Scrollbar, A11y, Autoplay],
+    };
+  },
+  inject: ["emitter"],
+  methods: {
+    goToProductPage(id) {
+      this.$router.push(`/product/${id}`);
+    },
+    addCart(item) {
+      const addItem = { product_id: item.id, qty: 1 };
+      const api = `${process.env.VUE_APP_API}api/${process.env.VUE_APP_PATH}/cart`;
+      this.status.addLoadingItem = item.id;
+      this.$http
+        .post(api, { data: addItem })
+        .then((res) => {
+          if (res.data.success) {
+            this.$pushMsg.status200(res, "已加入購物車");
+            this.emitter.emit("updateProductInCart");
+          } else {
+            this.$pushMsg.status200(res, "加入購物車失敗");
+          }
+        })
+        .catch((error) => {
+          this.$pushMsg.status404(error.response.data.message);
+        })
+        .finally(() => {
+          this.status.addLoadingItem = "";
+        });
+    },
+    isCurrentWidth() {
+      this.currentWidth = window.innerWidth;
+    },
+  },
+  created() {
+    this.isCurrentWidth();
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+.productItem:hover {
+  cursor: pointer;
+  // filter: brightness(1.1);
+}
+.bestSellersImg {
+  width: 100%;
+  height: 300px;
+  object-fit: cover;
+}
+
+.productItem:hover .bestSellersImg {
+  box-shadow: 0px 8px 10px rgba(36, 35, 35, 0.511) !important;
+}
+
+.addBtn {
+  width: 100%;
+}
+
+.productItem:hover .addBtn {
+  background-color: #ccaf3c;
+  border: 1px solid #ccaf3c;
+}
+
+.productItem .addBtn:hover {
+  background-color: #d4bb59;
+  border: 1px solid #d1b750;
+}
+
+.smStyle {
+  font-size: 14px;
+}
+
+:root .swiper-button-next,
+.swiper-button-prev {
+  --swiper-navigation-size: 20px;
+}
+
+.swiper-button-next {
+  position: absolute;
+  right: 0px;
+}
+
+.swiper-button-prev {
+  position: absolute;
+  left: 0px;
+}
+
+:root .swiper-button-next:hover,
+.swiper-button-prev:hover {
+  color: #ccaf3c !important;
+}
+</style>

--- a/src/components/frontend/BestSellers.vue
+++ b/src/components/frontend/BestSellers.vue
@@ -93,39 +93,6 @@
       <div class="swiper-button-prev text-dark"></div>
       <div class="swiper-button-next text-dark"></div>
     </Swiper>
-    <!-- <div
-      v-for="(item, index) in bestSellerProducts"
-      :key="item.id"
-      class="border pt-4 mb-4 px-3 col-10 col-sm-6 col-md-6 col-lg-3 col-xl-3"
-      data-aos="fade-up"
-      data-aos-duration="800"
-      :data-aos-delay="index * 100"
-    >
-      <router-link :to="`/product/${item.id}`" class="linkStyle">
-        <img
-          class="img-fluid bestSellersImg shadow-lg"
-          :src="item.imgUrl"
-          alt="bestSellerProductImg"
-        />
-      </router-link>
-      <div>
-        <div class="p-2 fs-5">{{ item.title }}</div>
-        <div class="px-2">{{ item.content }}</div>
-        <div class="d-flex p-2 justify-content-between">
-          <div class="text-decoration-line-through text-secondary">
-            NT$ {{ $filters.currency(item.origin_price) }}
-          </div>
-          <div class="text-end">NT$ {{ $filters.currency(item.price) }}</div>
-        </div>
-        <button
-          @click="addCart(item)"
-          class="w-100 my-3 btn btn-light shadow rounded-0"
-          type="button"
-        >
-          加入購物車
-        </button>
-      </div>
-    </div> -->
   </div>
 </template>
 

--- a/src/components/frontend/CategoryView.vue
+++ b/src/components/frontend/CategoryView.vue
@@ -1,127 +1,52 @@
 <template>
   <div class="bg-light">
     <main
-      class="mx-auto categoryWrap py-4 d-flex flex-wrap col-12 col-sm-9 col-lg-9 justify-content-center align-items-center"
+      class="mx-auto categoryWrap py-4 px-1 d-flex flex-wrap col-12 col-sm-9 col-lg-9 justify-content-center align-items-center"
     >
       <router-link
-        :to="`/user-products/${categoryList.veleafy_vegetable}`"
+        v-for="item in categoryList"
+        :key="item.name"
+        :to="`/user-products/${item.veleafy_vegetable}`"
         data-aos="zoom-in"
         data-aos-duration="600"
-        class="m-1 categoryLink text-secondary col col-sm"
+        class="categoryLink text-secondary col col-sm"
       >
-        <img
-          class="categoryImg"
-          src="@/assets/img/leafy_vegetable.png"
-          alt="leafy_vegetable_img"
-        />
+        <img class="categoryImg" :src="item.img" alt="leafy_vegetable_img" />
 
-        <p
-          class="mb-0 d-none d-sm-none d-md-block d-lg-block d-xl-block d-xxl-block"
-        >
-          {{ categoryList.veleafy_vegetable }}
+        <p class="mb-0 d-none d-md-block">
+          {{ item.name }}
         </p>
-        <p
-          class="mb-0 smFontSize d-block d-sm-block d-md-none d-lg-none d-xl-none d-xxl-none"
-        >
-          {{ categoryList.veleafy_vegetable }}
-        </p>
-      </router-link>
-      <router-link
-        :to="`/user-products/${categoryList.melon_root_bulb}`"
-        data-aos="zoom-in"
-        data-aos-duration="600"
-        class="m-1 categoryLink text-secondary col col-sm"
-      >
-        <img
-          class="categoryImg"
-          src="@/assets/img/melon_root_bulb.png"
-          alt="melon_root_bulb_img"
-        />
-        <p
-          class="mb-0 d-none d-sm-none d-md-block d-lg-block d-xl-block d-xxl-block"
-        >
-          {{ categoryList.melon_root_bulb }}
-        </p>
-
-        <p
-          class="mb-0 smFontSize d-block d-sm-block d-md-none d-lg-none d-xl-none d-xxl-none"
-        >
-          {{ categoryList.melon_root_bulb }}
-        </p>
-      </router-link>
-      <router-link
-        :to="`/user-products/${categoryList.mushroom}`"
-        data-aos="zoom-in"
-        data-aos-duration="600"
-        class="m-1 categoryLink text-secondary col col-sm"
-      >
-        <img
-          class="categoryImg"
-          src="@/assets/img/mushroom.png"
-          alt="mushroom_img"
-        />
-        <p
-          class="mb-0 d-none d-sm-none d-md-block d-lg-block d-xl-block d-xxl-block"
-        >
-          {{ categoryList.mushroom }}
-        </p>
-
-        <p
-          class="mb-0 smFontSize d-block d-sm-block d-md-none d-lg-none d-xl-none d-xxl-none"
-        >
-          {{ categoryList.mushroom }}
-        </p>
-      </router-link>
-      <router-link
-        :to="`/user-products/${categoryList.fruit}`"
-        data-aos="zoom-in"
-        data-aos-duration="600"
-        class="m-1 categoryLink text-secondary col col-sm"
-      >
-        <img class="categoryImg" src="@/assets/img/fruit.png" alt="fruit_img" />
-        <p
-          class="mb-0 d-none d-sm-none d-md-block d-lg-block d-xl-block d-xxl-block"
-        >
-          {{ categoryList.fruit }}
-        </p>
-        <p
-          class="mb-0 smFontSize d-block d-sm-block d-md-none d-lg-none d-xl-none d-xxl-none"
-        >
-          {{ categoryList.fruit }}
-        </p>
-      </router-link>
-      <router-link
-        :to="`/user-products/${categoryList.spice}`"
-        data-aos="zoom-in"
-        data-aos-duration="600"
-        class="m-1 categoryLink text-secondary col col-sm"
-      >
-        <img class="categoryImg" src="@/assets/img/spice.png" alt="spice_img" />
-        <p
-          class="mb-0 d-none d-sm-none d-md-block d-lg-block d-xl-block d-xxl-block"
-        >
-          {{ categoryList.spice }}
-        </p>
-        <p
-          class="mb-0 smFontSize d-block d-sm-block d-md-none d-lg-none d-xl-none d-xxl-none"
-        >
-          {{ categoryList.spice }}
+        <p class="mb-0 smFontSize d-block d-md-none">
+          {{ item.name }}
         </p>
       </router-link>
     </main>
   </div>
 </template>
 <script>
+import leafy_vegetableImg from "@/assets/img/leafy_vegetable.png";
+import melon_root_bulbImg from "@/assets/img/melon_root_bulb.png";
+import mushroomImg from "@/assets/img/mushroom.png";
+import fruitImg from "@/assets/img/fruit.png";
+import spiceImg from "@/assets/img/spice.png";
 export default {
   data() {
     return {
-      categoryList: {
-        veleafy_vegetable: "葉菜",
-        melon_root_bulb: "瓜果根球莖",
-        mushroom: "菇菌",
-        fruit: "水果",
-        spice: "辛香料",
-      },
+      categoryList: [
+        {
+          name: "葉菜",
+          type: "leafy_vegetable",
+          img: leafy_vegetableImg,
+        },
+        {
+          name: "瓜果根球莖",
+          type: "melon_root_bulb",
+          img: melon_root_bulbImg,
+        },
+        { name: "菇菌", type: "mushroom", img: mushroomImg },
+        { name: "水果", type: "fruit", img: fruitImg },
+        { name: "辛香料", type: "spice", img: spiceImg },
+      ],
     };
   },
 };
@@ -143,7 +68,7 @@ export default {
   justify-content: center;
   align-items: center;
   text-decoration: none;
-  min-width: 75px;
+  min-width: 90px;
 }
 
 .categoryLink:hover {

--- a/src/components/frontend/CategoryView.vue
+++ b/src/components/frontend/CategoryView.vue
@@ -1,113 +1,115 @@
 <template>
-  <section
-    class="categoryWrap bg-light-gray row m-0 flex-wrap justify-content-center align-items-center"
-  >
-    <router-link
-      :to="`/user-products/${categoryList.veleafy_vegetable}`"
-      data-aos="zoom-in"
-      data-aos-duration="600"
-      class="m-1 categoryLink text-secondary col-2 col-lg-1"
+  <div class="bg-light">
+    <main
+      class="mx-auto categoryWrap py-4 d-flex flex-wrap col-12 col-sm-9 col-lg-9 justify-content-center align-items-center"
     >
-      <img
-        class="categoryImg"
-        src="@/assets/img/leafy_vegetable.png"
-        alt="leafy_vegetable_img"
-      />
+      <router-link
+        :to="`/user-products/${categoryList.veleafy_vegetable}`"
+        data-aos="zoom-in"
+        data-aos-duration="600"
+        class="m-1 categoryLink text-secondary col col-sm"
+      >
+        <img
+          class="categoryImg"
+          src="@/assets/img/leafy_vegetable.png"
+          alt="leafy_vegetable_img"
+        />
 
-      <p
-        class="mb-0 d-none d-sm-none d-md-block d-lg-block d-xl-block d-xxl-block"
+        <p
+          class="mb-0 d-none d-sm-none d-md-block d-lg-block d-xl-block d-xxl-block"
+        >
+          {{ categoryList.veleafy_vegetable }}
+        </p>
+        <p
+          class="mb-0 smFontSize d-block d-sm-block d-md-none d-lg-none d-xl-none d-xxl-none"
+        >
+          {{ categoryList.veleafy_vegetable }}
+        </p>
+      </router-link>
+      <router-link
+        :to="`/user-products/${categoryList.melon_root_bulb}`"
+        data-aos="zoom-in"
+        data-aos-duration="600"
+        class="m-1 categoryLink text-secondary col col-sm"
       >
-        {{ categoryList.veleafy_vegetable }}
-      </p>
-      <p
-        class="mb-0 smFontSize d-block d-sm-block d-md-none d-lg-none d-xl-none d-xxl-none"
-      >
-        {{ categoryList.veleafy_vegetable }}
-      </p>
-    </router-link>
-    <router-link
-      :to="`/user-products/${categoryList.melon_root_bulb}`"
-      data-aos="zoom-in"
-      data-aos-duration="600"
-      class="m-1 categoryLink text-secondary col-2 col-lg-1"
-    >
-      <img
-        class="categoryImg"
-        src="@/assets/img/melon_root_bulb.png"
-        alt="melon_root_bulb_img"
-      />
-      <p
-        class="mb-0 d-none d-sm-none d-md-block d-lg-block d-xl-block d-xxl-block"
-      >
-        {{ categoryList.melon_root_bulb }}
-      </p>
+        <img
+          class="categoryImg"
+          src="@/assets/img/melon_root_bulb.png"
+          alt="melon_root_bulb_img"
+        />
+        <p
+          class="mb-0 d-none d-sm-none d-md-block d-lg-block d-xl-block d-xxl-block"
+        >
+          {{ categoryList.melon_root_bulb }}
+        </p>
 
-      <p
-        class="mb-0 smFontSize d-block d-sm-block d-md-none d-lg-none d-xl-none d-xxl-none"
+        <p
+          class="mb-0 smFontSize d-block d-sm-block d-md-none d-lg-none d-xl-none d-xxl-none"
+        >
+          {{ categoryList.melon_root_bulb }}
+        </p>
+      </router-link>
+      <router-link
+        :to="`/user-products/${categoryList.mushroom}`"
+        data-aos="zoom-in"
+        data-aos-duration="600"
+        class="m-1 categoryLink text-secondary col col-sm"
       >
-        {{ categoryList.melon_root_bulb }}
-      </p>
-    </router-link>
-    <router-link
-      :to="`/user-products/${categoryList.mushroom}`"
-      data-aos="zoom-in"
-      data-aos-duration="600"
-      class="m-1 categoryLink text-secondary col-2 col-lg-1"
-    >
-      <img
-        class="categoryImg"
-        src="@/assets/img/mushroom.png"
-        alt="mushroom_img"
-      />
-      <p
-        class="mb-0 d-none d-sm-none d-md-block d-lg-block d-xl-block d-xxl-block"
-      >
-        {{ categoryList.mushroom }}
-      </p>
+        <img
+          class="categoryImg"
+          src="@/assets/img/mushroom.png"
+          alt="mushroom_img"
+        />
+        <p
+          class="mb-0 d-none d-sm-none d-md-block d-lg-block d-xl-block d-xxl-block"
+        >
+          {{ categoryList.mushroom }}
+        </p>
 
-      <p
-        class="mb-0 smFontSize d-block d-sm-block d-md-none d-lg-none d-xl-none d-xxl-none"
+        <p
+          class="mb-0 smFontSize d-block d-sm-block d-md-none d-lg-none d-xl-none d-xxl-none"
+        >
+          {{ categoryList.mushroom }}
+        </p>
+      </router-link>
+      <router-link
+        :to="`/user-products/${categoryList.fruit}`"
+        data-aos="zoom-in"
+        data-aos-duration="600"
+        class="m-1 categoryLink text-secondary col col-sm"
       >
-        {{ categoryList.mushroom }}
-      </p>
-    </router-link>
-    <router-link
-      :to="`/user-products/${categoryList.fruit}`"
-      data-aos="zoom-in"
-      data-aos-duration="600"
-      class="m-1 categoryLink text-secondary col-2 col-lg-1"
-    >
-      <img class="categoryImg" src="@/assets/img/fruit.png" alt="fruit_img" />
-      <p
-        class="mb-0 d-none d-sm-none d-md-block d-lg-block d-xl-block d-xxl-block"
+        <img class="categoryImg" src="@/assets/img/fruit.png" alt="fruit_img" />
+        <p
+          class="mb-0 d-none d-sm-none d-md-block d-lg-block d-xl-block d-xxl-block"
+        >
+          {{ categoryList.fruit }}
+        </p>
+        <p
+          class="mb-0 smFontSize d-block d-sm-block d-md-none d-lg-none d-xl-none d-xxl-none"
+        >
+          {{ categoryList.fruit }}
+        </p>
+      </router-link>
+      <router-link
+        :to="`/user-products/${categoryList.spice}`"
+        data-aos="zoom-in"
+        data-aos-duration="600"
+        class="m-1 categoryLink text-secondary col col-sm"
       >
-        {{ categoryList.fruit }}
-      </p>
-      <p
-        class="mb-0 smFontSize d-block d-sm-block d-md-none d-lg-none d-xl-none d-xxl-none"
-      >
-        {{ categoryList.fruit }}
-      </p>
-    </router-link>
-    <router-link
-      :to="`/user-products/${categoryList.spice}`"
-      data-aos="zoom-in"
-      data-aos-duration="600"
-      class="m-1 categoryLink text-secondary col-2 col-lg-1"
-    >
-      <img class="categoryImg" src="@/assets/img/spice.png" alt="spice_img" />
-      <p
-        class="mb-0 d-none d-sm-none d-md-block d-lg-block d-xl-block d-xxl-block"
-      >
-        {{ categoryList.spice }}
-      </p>
-      <p
-        class="mb-0 smFontSize d-block d-sm-block d-md-none d-lg-none d-xl-none d-xxl-none"
-      >
-        {{ categoryList.spice }}
-      </p>
-    </router-link>
-  </section>
+        <img class="categoryImg" src="@/assets/img/spice.png" alt="spice_img" />
+        <p
+          class="mb-0 d-none d-sm-none d-md-block d-lg-block d-xl-block d-xxl-block"
+        >
+          {{ categoryList.spice }}
+        </p>
+        <p
+          class="mb-0 smFontSize d-block d-sm-block d-md-none d-lg-none d-xl-none d-xxl-none"
+        >
+          {{ categoryList.spice }}
+        </p>
+      </router-link>
+    </main>
+  </div>
 </template>
 <script>
 export default {
@@ -141,15 +143,17 @@ export default {
   justify-content: center;
   align-items: center;
   text-decoration: none;
+  min-width: 75px;
 }
 
 .categoryLink:hover {
-  border-radius: 5%;
-  background-color: rgba(249, 196, 6, 0.292);
+  border-radius: 6px;
+  background-color: #f9c40637;
   color: #000 !important;
+  filter: brightness(1.1);
 }
 
 .smFontSize {
-  font-size: 12px;
+  font-size: 14px;
 }
 </style>

--- a/src/components/frontend/CategoryView.vue
+++ b/src/components/frontend/CategoryView.vue
@@ -1,27 +1,55 @@
 <template>
   <div class="bg-light">
-    <main
-      class="mx-auto py-4 px-1 d-flex flex-wrap col-12 col-lg-9 justify-content-center align-items-center"
+    <Swiper
+      class="swiper mx-auto py-4 px-1 d-flex flex-wrap col-12 col-lg-9 justify-content-center align-items-center"
+      :modules="modules"
+      :freeMode="true"
+      :slides-per-view="5"
+      :space-between="10"
+      :grabCursor="true"
+      :pagination="{
+        clickable: true,
+        el: '.swiper-pagination',
+      }"
+      :scrollbar="false"
+      :breakpoints="{
+        '0': {
+          slidesPerView: 1,
+        },
+        '220': {
+          slidesPerView: 2,
+        },
+        '320': {
+          slidesPerView: 3,
+        },
+        '420': {
+          slidesPerView: 4,
+        },
+        '500': {
+          slidesPerView: 5,
+        },
+      }"
+      @swiper="onSwiper"
+      @slideChange="onSlideChange"
     >
-      <router-link
+      <SwiperSlide
         v-for="item in categoryList"
         :key="item.name"
-        :to="`/user-products/${item.veleafy_vegetable}`"
-        data-aos="zoom-in"
-        data-aos-duration="600"
-        class="categoryLink py-2 px-1 text-secondary text-decoration-none d-flex flex-column justify-content-center align-items-center col-4 col-sm"
+        class="mb-2 d-flex jusitify-content-center"
       >
-        <img
-          class="categoryImg mb-1"
-          :src="item.img"
-          alt="leafy_vegetable_img"
-        />
+        <router-link
+          :to="`/user-products/${item.name}`"
+          class="categoryLink py-2 px-1 text-secondary text-decoration-none d-flex flex-column justify-content-center align-items-center col-4 col-sm"
+        >
+          <img class="categoryImg mb-1" :src="item.img" alt="category_img" />
 
-        <p class="mb-0">
-          {{ item.name }}
-        </p>
-      </router-link>
-    </main>
+          <p class="mb-0">
+            {{ item.name }}
+          </p>
+        </router-link>
+      </SwiperSlide>
+      <div class="swiper-pagination"></div>
+    </Swiper>
   </div>
 </template>
 <script>
@@ -30,6 +58,18 @@ import melon_root_bulbImg from "@/assets/img/melon_root_bulb.png";
 import mushroomImg from "@/assets/img/mushroom.png";
 import fruitImg from "@/assets/img/fruit.png";
 import spiceImg from "@/assets/img/spice.png";
+import {
+  Navigation,
+  Pagination,
+  Scrollbar,
+  A11y,
+  Autoplay,
+} from "swiper/modules";
+import { Swiper, SwiperSlide } from "swiper/vue";
+import "swiper/css";
+import "swiper/css/navigation";
+import "swiper/css/pagination";
+import "swiper/css/scrollbar";
 export default {
   data() {
     return {
@@ -50,6 +90,19 @@ export default {
       ],
     };
   },
+  components: {
+    Swiper,
+    SwiperSlide,
+  },
+  setup() {
+    const onSwiper = () => {};
+    const onSlideChange = () => {};
+    return {
+      onSwiper,
+      onSlideChange,
+      modules: [Navigation, Pagination, Scrollbar, A11y, Autoplay],
+    };
+  },
 };
 </script>
 <style lang="scss" scoped>
@@ -62,9 +115,18 @@ export default {
 }
 
 .categoryLink:hover {
+  width: 100%;
   border-radius: 6px;
   background-color: #f9c40637;
   color: #000 !important;
   filter: brightness(1.1);
+}
+
+.swiper-slide {
+  justify-content: center;
+}
+
+.swiper {
+  --swiper-pagination-color: #ccaf3c;
 }
 </style>

--- a/src/components/frontend/CategoryView.vue
+++ b/src/components/frontend/CategoryView.vue
@@ -116,10 +116,9 @@ export default {
 
 .categoryLink:hover {
   width: 100%;
-  border-radius: 6px;
-  background-color: #f9c40637;
   color: #000 !important;
-  filter: brightness(1.1);
+  font-weight: bolder;
+  filter: brightness(1.3);
 }
 
 .swiper-slide {

--- a/src/components/frontend/CategoryView.vue
+++ b/src/components/frontend/CategoryView.vue
@@ -38,6 +38,8 @@
         class="mb-2 d-flex jusitify-content-center"
       >
         <router-link
+          data-aos="zoom-in"
+          data-aos-duration="600"
           :to="`/user-products/${item.name}`"
           class="categoryLink py-2 px-1 text-secondary text-decoration-none d-flex flex-column justify-content-center align-items-center col-4 col-sm"
         >

--- a/src/components/frontend/CategoryView.vue
+++ b/src/components/frontend/CategoryView.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="bg-light">
     <main
-      class="mx-auto categoryWrap py-4 px-1 d-flex flex-wrap col-12 col-sm-9 col-lg-9 justify-content-center align-items-center"
+      class="mx-auto py-4 px-1 d-flex flex-wrap col-12 col-lg-9 justify-content-center align-items-center"
     >
       <router-link
         v-for="item in categoryList"
@@ -9,14 +9,15 @@
         :to="`/user-products/${item.veleafy_vegetable}`"
         data-aos="zoom-in"
         data-aos-duration="600"
-        class="categoryLink text-secondary col col-sm"
+        class="categoryLink py-2 px-1 text-secondary text-decoration-none d-flex flex-column justify-content-center align-items-center col-4 col-sm"
       >
-        <img class="categoryImg" :src="item.img" alt="leafy_vegetable_img" />
+        <img
+          class="categoryImg mb-1"
+          :src="item.img"
+          alt="leafy_vegetable_img"
+        />
 
-        <p class="mb-0 d-none d-md-block">
-          {{ item.name }}
-        </p>
-        <p class="mb-0 smFontSize d-block d-md-none">
+        <p class="mb-0">
           {{ item.name }}
         </p>
       </router-link>
@@ -52,22 +53,11 @@ export default {
 };
 </script>
 <style lang="scss" scoped>
-.categoryWrap {
-  padding: 10px 0px;
-}
-
 .categoryImg {
   width: 50px;
-  margin-bottom: 6px;
 }
 
 .categoryLink {
-  padding: 5px 0px;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  text-decoration: none;
   min-width: 90px;
 }
 
@@ -76,9 +66,5 @@ export default {
   background-color: #f9c40637;
   color: #000 !important;
   filter: brightness(1.1);
-}
-
-.smFontSize {
-  font-size: 14px;
 }
 </style>

--- a/src/components/frontend/DiscountNews.vue
+++ b/src/components/frontend/DiscountNews.vue
@@ -1,0 +1,57 @@
+<template>
+  <main>
+    <div
+      class="position-relative d-flex justify-content-center align-items-center"
+    >
+      <img
+        class="newsImg object-fit-cover col-12 p-0"
+        data-aos="fade-zoom-in"
+        data-aos-easing="ease-out-circ"
+        data-aos-duration="2000"
+        src="@/assets/img/home_img2.jpg"
+        alt="homeImg"
+      />
+      <router-link
+        to="/user-products"
+        class="newsContent px-1 text-decoration-none text-black col-11 col-sm-9 col-lg-8 col-xl-6 d-flex flex-column justify-content-center align-items-center"
+        data-aos="zoom-in"
+        data-aos-easing="ease-out-sine"
+        data-aos-duration="900"
+      >
+        <div class="fs-1 fw-bold mb-3">全 館 滿 千 免 運</div>
+        <p class="fs-4 fw-bold text-center mb-4">
+          結帳代入
+          <span class="border border-secondary rounded px-1 py-1 fw-bold me-1">
+            10%off
+          </span>
+          享 9 折優惠
+        </p>
+        <p
+          class="fw-bold fs-5 mb-0 bg-primary border border-primary px-4 py-1 rounded goShopping"
+        >
+          去 逛 逛 吧 !
+        </p>
+      </router-link>
+    </div>
+  </main>
+</template>
+<style lang="scss" scoped>
+.newsImg {
+  height: 300px;
+}
+
+.newsContent {
+  position: absolute;
+  height: 250px;
+  background-color: rgba(252, 251, 251, 0.832);
+}
+
+.newsContent:hover {
+  filter: brightness(1.1);
+}
+
+.newsContent .goShopping:hover {
+  background-color: #d4bb59 !important;
+  border: 1px solid #d1b750 !important;
+}
+</style>

--- a/src/components/frontend/DiscountNews.vue
+++ b/src/components/frontend/DiscountNews.vue
@@ -13,13 +13,13 @@
       />
       <router-link
         to="/user-products"
-        class="newsContent px-1 text-decoration-none text-black col-11 col-sm-9 col-lg-8 col-xl-6 d-flex flex-column justify-content-center align-items-center"
+        class="rounded newsContent px-1 text-decoration-none text-black col-11 col-sm-9 col-lg-8 col-xl-6 d-flex flex-column justify-content-center align-items-center"
         data-aos="zoom-in"
         data-aos-easing="ease-out-sine"
         data-aos-duration="900"
       >
-        <div class="fs-1 fw-bold mb-3">全 館 滿 千 免 運</div>
-        <p class="fs-4 fw-bold text-center mb-4">
+        <p class="mb-0 fw-bold mb-3 text-center newsTitle">全 館 滿 千 免 運</p>
+        <p class="fw-bold text-center mb-4 newsText">
           結帳代入
           <span class="border border-secondary rounded px-1 py-1 fw-bold me-1">
             10%off
@@ -27,7 +27,7 @@
           享 9 折優惠
         </p>
         <p
-          class="fw-bold fs-5 mb-0 bg-primary border border-primary px-4 py-1 rounded goShopping"
+          class="text-center fw-bold mb-0 bg-primary border border-primary px-4 py-1 rounded goShopping"
         >
           去 逛 逛 吧 !
         </p>
@@ -48,6 +48,18 @@
 
 .newsContent:hover {
   filter: brightness(1.1);
+}
+
+.newsTitle {
+  font-size: clamp(26px, 4vw, 40px);
+}
+
+.newsText {
+  font-size: clamp(22px, 4vw, 28px);
+}
+
+.goShopping {
+  font-size: clamp(18px, 2.5vw, 24px);
 }
 
 .newsContent .goShopping:hover {

--- a/src/components/frontend/SwiperImgs.vue
+++ b/src/components/frontend/SwiperImgs.vue
@@ -46,22 +46,13 @@
             alt="carouselImg"
           />
           <div>
-            <div
-              class="p-2 fs-5 text-black"
-              :class="{ 'fs-6 fw-bold': currentWidth < 600 }"
-            >
+            <div class="p-2 fs-5 fw-bold text-black">
               {{ item.title }}
             </div>
-            <div
-              class="px-2 text-black"
-              :class="{ 'smStyle fw-light': currentWidth < 600 }"
-            >
+            <div class="px-2 text-black">
               {{ item.content }}
             </div>
-            <div
-              :class="{ 'smStyle fw-light': currentWidth < 600 }"
-              class="priceContainer d-flex p-2 flex-wrap align-items-center"
-            >
+            <div class="priceContainer d-flex p-2 flex-wrap align-items-center">
               <div
                 class="text-secondary col-12"
                 :class="{
@@ -81,7 +72,6 @@
             <div class="text-center pb-2">
               <button
                 @click.stop="addCart(item)"
-                :class="{ 'btn-sm': currentWidth < 600 }"
                 class="mb-0 btn btn-light addBtn"
                 type="button"
               >
@@ -120,7 +110,6 @@ export default {
   data() {
     return {
       allProducts: [],
-      currentWidth: "1000",
       status: {
         addLoadingItem: "",
         delLoadingItem: "",
@@ -176,11 +165,7 @@ export default {
           this.status.addLoadingItem = "";
         });
     },
-    isCurrentWidth() {
-      this.currentWidth = window.innerWidth;
-    },
     goToProductPage(id) {
-      console.log(id);
       this.$router.push(`/product/${id}`);
       if (this.$route.path !== "/") {
         setTimeout(() => {
@@ -191,7 +176,6 @@ export default {
   },
 
   created() {
-    this.isCurrentWidth();
     this.getAllProducts();
   },
 };
@@ -229,10 +213,6 @@ a {
   width: 100%;
   height: 150px;
   object-fit: cover;
-}
-
-.smStyle {
-  font-size: 14px;
 }
 
 .priceContainer {

--- a/src/components/frontend/SwiperImgs.vue
+++ b/src/components/frontend/SwiperImgs.vue
@@ -26,11 +26,11 @@
           slidesPerView: 2,
           spaceBetween: 45,
         },
-        '800': {
+        '750': {
           slidesPerView: 3,
           spaceBetween: 45,
         },
-        '1200': {
+        '900': {
           slidesPerView: 4,
           spaceBetween: 45,
         },

--- a/src/views/frontend/HomeView.vue
+++ b/src/views/frontend/HomeView.vue
@@ -9,9 +9,9 @@
   />
 
   <!-- 商品類別 -->
-  <CategoryView />
+  <CategoryView class="mb-5" />
   <!-- 暢銷商品 -->
-  <section class="d-flex justify-content-center mt-5">
+  <section class="d-flex justify-content-center">
     <div class="row mx-0 mb-5 pb-3 pt-4 col-11 justify-content-center">
       <h3
         class="writeStyle m-0 col-1"

--- a/src/views/frontend/HomeView.vue
+++ b/src/views/frontend/HomeView.vue
@@ -20,37 +20,14 @@
     >
       暢銷商品
     </h3>
-
     <BestSellers />
   </section>
-
-  <section class="row col-12 mx-0 justify-content-center align-items-center">
-    <img
-      class="newsImg object-fit-cover col-lg-12 p-0"
-      data-aos="fade-zoom-in"
-      data-aos-easing="ease-out-circ"
-      data-aos-duration="2000"
-      src="@/assets/img/home_img2.jpg"
-      alt="homeImg"
-    />
-    <router-link
-      to="/user-products"
-      class="newsContent text-decoration-none text-black col-11 col-sm-9 col-lg-8 col-xl-6 d-flex flex-column justify-content-center align-items-center"
-      data-aos="zoom-in"
-      data-aos-easing="ease-out-sine"
-      data-aos-duration="900"
-    >
-      <div class="fs-1 fw-lighter mb-3">全館滿千免運</div>
-      <div class="fs-4 fw-lighter text-center mb-3">
-        結帳代入
-        <span class="border border-secondary px-2 py-1">10%off</span>
-        享 9 折優惠
-      </div>
-      <div class="goShopping fw-lighter fs-5">去 逛 逛</div>
-    </router-link>
+  <!-- 優惠消息 -->
+  <section class="mb-5 col-12">
+    <DiscountNews />
   </section>
-
-  <section class="mx-auto py-5 col-11 col-xl-9">
+  <!-- 精選商品 -->
+  <section class="mx-auto mb-5 col-11 col-xl-9">
     <h3
       class="mb-3 border-bottom border-dark"
       data-aos="fade-in"
@@ -71,70 +48,12 @@
 import CategoryView from "@/components/frontend/CategoryView.vue";
 import BestSellers from "@/components/frontend/BestSellers.vue";
 import SwiperImgs from "@/components/frontend/SwiperImgs.vue";
+import DiscountNews from "@/components/frontend/DiscountNews.vue";
 export default {
   data() {
-    return {
-      bestSellerProducts: [
-        {
-          title: "台灣水蜜桃",
-          imgUrl:
-            "https://images.unsplash.com/photo-1595124245030-41448b199d6d?q=80&w=1965&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-          content: "600g±10% / 盒",
-          origin_price: 600,
-          price: 500,
-          id: "-NsfVCnYqjTKonXqR4cO",
-        },
-        {
-          title: "無籽黑葡萄",
-          imgUrl:
-            "https://images.unsplash.com/photo-1601275868399-45bec4f4cd9d?q=80&w=1935&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-          content: "1.8kg±10% / 盒",
-          origin_price: 699,
-          price: 569,
-          id: "-Nsg6Th1g1I7OzbPJF1g",
-        },
-        {
-          title: "空運櫻桃",
-          imgUrl:
-            "https://images.unsplash.com/photo-1595657241488-468423581c23?q=80&w=1974&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-          content: "1kg±10% / 盒",
-          origin_price: 1200,
-          price: 1000,
-          id: "-NsfbLG9v4NLUQwba1YJ",
-        },
-        {
-          title: "蘆筍",
-          imgUrl:
-            "https://images.unsplash.com/photo-1629875235136-737fef945cfd?q=80&w=2070&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
-          content: "200g±10% / 盒",
-          origin_price: 150,
-          price: 120,
-          id: "-Ntoe6-WbDJY9ChStYOs",
-        },
-      ],
-    };
+    return {};
   },
-  components: { CategoryView, BestSellers, SwiperImgs },
-  inject: ["emitter"],
-  methods: {
-    addCart(item) {
-      const addItem = { product_id: item.id, qty: 1 };
-      const api = `${process.env.VUE_APP_API}api/${process.env.VUE_APP_PATH}/cart`;
-      this.$http
-        .post(api, { data: addItem })
-        .then((res) => {
-          if (res.data.success) {
-            this.$pushMsg.status200(res, "已加入購物車");
-            this.emitter.emit("updateProductInCart");
-          } else {
-            this.$pushMsg.status200(res, "加入購物車失敗");
-          }
-        })
-        .catch((error) => {
-          this.$pushMsg.status404(error.response.data.message);
-        });
-    },
-  },
+  components: { CategoryView, BestSellers, DiscountNews, SwiperImgs },
 };
 </script>
 
@@ -143,44 +62,5 @@ export default {
   width: 100%;
   height: 100vh;
   object-fit: cover;
-}
-
-.straightLine {
-  width: 1px;
-  background-color: black;
-  height: 180px;
-}
-
-.bestSellersImg {
-  width: 100%;
-  height: 300px;
-  object-fit: cover;
-}
-
-.bestSellersImg:hover {
-  box-shadow: 0px 8px 10px rgba(36, 35, 35, 0.511) !important;
-}
-
-.newsImg {
-  height: 300px;
-}
-
-.newsContent {
-  height: 250px;
-  background-color: rgba(252, 251, 251, 0.832);
-  position: absolute;
-}
-
-.goShopping {
-  opacity: 0;
-  transition: opacity 0.3s ease;
-}
-
-.newsContent:hover {
-  box-shadow: 0px 8px 10px rgba(36, 35, 35, 0.511);
-}
-
-.newsContent:hover .goShopping {
-  opacity: 1;
 }
 </style>

--- a/src/views/frontend/HomeView.vue
+++ b/src/views/frontend/HomeView.vue
@@ -1,12 +1,34 @@
 <template>
-  <img
-    src="@/assets/img/1.jpg"
-    class="homeImg"
-    alt="homeImg"
-    data-aos="fade-in"
-    data-aos-easing="ease-out-sine"
-    data-aos-duration="2000"
-  />
+  <div class="position-relative d-flex justify-content-center">
+    <img
+      src="@/assets/img/1.jpg"
+      class="homeImg"
+      alt="homeImg"
+      data-aos="fade-in"
+      data-aos-easing="ease-out-sine"
+      data-aos-duration="2000"
+    />
+    <div
+      class="fastGoBox position-absolute rounded p-5 text-center col-11 col-sm-11 col-md-9"
+    >
+      <p class="fs-1 text-light fw-bold">新 鮮 食 材 更 有 好 味 道</p>
+      <p class="fs-1 text-light fw-bold">當 季 蔬 果 熱 賣 中</p>
+      <router-link
+        to="/user-products"
+        class="btn btn-primary btn-lg"
+        role="button"
+      >
+        快速前往購物吧
+      </router-link>
+    </div>
+    <div
+      class="scrollBox w-100 py-2 px-3 position-absolute d-flex justify-content-center"
+    >
+      <button class="btn btn arrowBtn" type="button ">
+        <i class="fs-1 bi bi-arrow-down"></i>
+      </button>
+    </div>
+  </div>
 
   <!-- 商品類別 -->
   <CategoryView class="mb-5" />
@@ -60,7 +82,43 @@ export default {
 <style lang="scss" scoped>
 .homeImg {
   width: 100%;
-  height: 82vh;
+  height: 100vh;
   object-fit: cover;
+}
+
+.fastGoBox {
+  bottom: 30%;
+  background-color: #0000004d;
+}
+
+.fastGoBox:hover {
+  filter: brightness(1.3);
+}
+
+.scrollBox {
+  height: 250px;
+  bottom: 0px;
+}
+
+.arrowBtn {
+  position: absolute;
+  top: 0px;
+  animation-name: arrow;
+  animation-duration: 5s;
+  animation-iteration-count: infinite;
+}
+
+@keyframes arrow {
+  0% {
+    color: #fff;
+    top: 20px;
+    opacity: 1;
+  }
+
+  100% {
+    color: #fff;
+    top: 200px;
+    opacity: 0;
+  }
 }
 </style>

--- a/src/views/frontend/HomeView.vue
+++ b/src/views/frontend/HomeView.vue
@@ -11,56 +11,17 @@
   <!-- 商品類別 -->
   <CategoryView class="mb-5" />
   <!-- 暢銷商品 -->
-  <section class="d-flex justify-content-center">
-    <div class="row mx-0 mb-5 pb-3 pt-4 col-11 justify-content-center">
-      <h3
-        class="writeStyle m-0 col-1"
-        data-aos="fade-in"
-        data-aos-easing="ease-out-sine"
-        data-aos-duration="1500"
-      >
-        暢銷商品
-        <div class="straightLine writeStyle mt-3 ms-2"></div>
-      </h3>
+  <section class="mx-auto mb-5 col-11 col-xl-9">
+    <h3
+      class="mb-3 border-bottom border-dark"
+      data-aos="fade-in"
+      data-aos-easing="ease-out-sine"
+      data-aos-duration="1500"
+    >
+      暢銷商品
+    </h3>
 
-      <div class="col col-md-11 col-xl-9 row m-0 justify-content-center">
-        <div
-          v-for="(item, index) in bestSellerProducts"
-          :key="item.id"
-          class="pt-4 mb-4 col-10 col-sm-6 col-md-6 col-lg-3 col-xl"
-          data-aos="fade-up"
-          data-aos-duration="800"
-          :data-aos-delay="index * 100"
-        >
-          <router-link :to="`/product/${item.id}`" class="linkStyle">
-            <img
-              class="img-fluid bestSellersImg shadow-lg"
-              :src="item.imgUrl"
-              alt="bestSellerProductImg"
-            />
-          </router-link>
-          <div>
-            <div class="p-2 fs-5">{{ item.title }}</div>
-            <div class="px-2">{{ item.content }}</div>
-            <div class="d-flex p-2 justify-content-between">
-              <div class="text-decoration-line-through text-secondary">
-                NT$ {{ $filters.currency(item.origin_price) }}
-              </div>
-              <div class="text-end">
-                NT$ {{ $filters.currency(item.price) }}
-              </div>
-            </div>
-            <button
-              @click="addCart(item)"
-              class="w-100 my-3 btn btn-light shadow rounded-0"
-              type="button"
-            >
-              加入購物車
-            </button>
-          </div>
-        </div>
-      </div>
-    </div>
+    <BestSellers />
   </section>
 
   <section class="row col-12 mx-0 justify-content-center align-items-center">
@@ -89,30 +50,26 @@
     </router-link>
   </section>
 
-  <section class="py-5 col-12">
-    <div class="mx-auto col-11 py-5">
-      <div class="row my-0 mx-auto flex-row-reverse col-11">
-        <h3
-          class="writeStyle m-0 p-0 col-1"
-          data-aos="fade-in"
-          data-aos-easing="ease-out-sine"
-          data-aos-duration="1500"
-        >
-          <div class="straightLine writeStyle mt-3 me-2"></div>
-          精選商品
-        </h3>
-        <SwiperImgs
-          class="mx-auto overflow-x-hidden pt-3 col-10"
-          data-aos="fade-up"
-          data-aos-easing="ease-out-sine"
-          data-aos-duration="800"
-        />
-      </div>
-    </div>
+  <section class="mx-auto py-5 col-11 col-xl-9">
+    <h3
+      class="mb-3 border-bottom border-dark"
+      data-aos="fade-in"
+      data-aos-easing="ease-out-sine"
+      data-aos-duration="1500"
+    >
+      精選商品
+    </h3>
+    <SwiperImgs
+      class="mx-auto overflow-x-hidden"
+      data-aos="fade-up"
+      data-aos-easing="ease-out-sine"
+      data-aos-duration="800"
+    />
   </section>
 </template>
 <script>
 import CategoryView from "@/components/frontend/CategoryView.vue";
+import BestSellers from "@/components/frontend/BestSellers.vue";
 import SwiperImgs from "@/components/frontend/SwiperImgs.vue";
 export default {
   data() {
@@ -157,7 +114,7 @@ export default {
       ],
     };
   },
-  components: { CategoryView, SwiperImgs },
+  components: { CategoryView, BestSellers, SwiperImgs },
   inject: ["emitter"],
   methods: {
     addCart(item) {
@@ -186,10 +143,6 @@ export default {
   width: 100%;
   height: 100vh;
   object-fit: cover;
-}
-
-.writeStyle {
-  writing-mode: vertical-lr;
 }
 
 .straightLine {

--- a/src/views/frontend/HomeView.vue
+++ b/src/views/frontend/HomeView.vue
@@ -9,10 +9,10 @@
       data-aos-duration="2000"
     />
     <div
-      class="fastGoBox position-absolute rounded p-5 text-center col-11 col-sm-11 col-md-9"
+      class="fastGoBox position-absolute rounded py-5 px-3 text-center col-11 col-sm-11 col-md-9"
     >
-      <p class="fs-1 text-light fw-bold">新 鮮 食 材 更 有 好 味 道</p>
-      <p class="fs-1 text-light fw-bold">當 季 蔬 果 熱 賣 中</p>
+      <p class="bannerText text-light fw-bold">新 鮮 食 材 更 有 好 味 道</p>
+      <p class="bannerText text-light fw-bold">當 季 蔬 果 熱 賣 中</p>
       <router-link
         to="/user-products"
         class="btn btn-primary btn-lg"
@@ -91,6 +91,10 @@ export default {
 
 .fastGoBox:hover {
   filter: brightness(1.3);
+}
+
+.bannerText {
+  font-size: clamp(24px, 4vw, 40px);
 }
 
 .scrollBox {

--- a/src/views/frontend/HomeView.vue
+++ b/src/views/frontend/HomeView.vue
@@ -24,9 +24,7 @@
     <div
       class="scrollBox w-100 py-2 px-3 position-absolute d-flex justify-content-center"
     >
-      <button class="btn btn arrowBtn" type="button ">
-        <i class="fs-1 bi bi-arrow-down"></i>
-      </button>
+      <i class="arrowDown text-white fs-1 bi-arrow-down-circle-fill"></i>
     </div>
   </div>
 
@@ -100,7 +98,7 @@ export default {
   bottom: 0px;
 }
 
-.arrowBtn {
+.arrowDown {
   position: absolute;
   top: 0px;
   animation-name: arrow;
@@ -110,13 +108,11 @@ export default {
 
 @keyframes arrow {
   0% {
-    color: #fff;
-    top: 20px;
+    top: 0px;
     opacity: 1;
   }
 
   100% {
-    color: #fff;
     top: 200px;
     opacity: 0;
   }

--- a/src/views/frontend/HomeView.vue
+++ b/src/views/frontend/HomeView.vue
@@ -60,7 +60,7 @@ export default {
 <style lang="scss" scoped>
 .homeImg {
   width: 100%;
-  height: 100vh;
+  height: 82vh;
   object-fit: cover;
 }
 </style>

--- a/src/views/frontend/ProductDetails.vue
+++ b/src/views/frontend/ProductDetails.vue
@@ -195,6 +195,9 @@ export default {
         })
         .catch((error) => {
           this.$pushMsg.status404(error.response.data.message);
+        })
+        .finally(() => {
+          window.scrollTo(0, 0);
         });
     },
     addQty() {


### PR DESCRIPTION
### **設計師建議**
-  區塊間距建議保持一致，目前商品分類與 Banner 的間距明顯較其他區塊小

![17537644344834531270_2024-08-02T05-49-23Z](https://github.com/user-attachments/assets/229c6cbe-2207-45b8-94ed-4d9fe6d12162)

-  建議利用字重、字級、顏色來營造層次感，標題可以使用較大的字級（20px）並加粗，特價可使用主色或強調色

![蘆筍](https://github.com/user-attachments/assets/e39ee201-d36a-4c68-b6c7-5c375609748e)

-  優惠區塊的文字有些不好閱讀，建議使用粗體呈現
-  要注意手機版沒有 Hover 效果，不建議在將 CTA 藏在 Hover 狀態內，直接顯示即可
-  「去逛逛」建議可以使用按鈕形式呈現

![17537644344834531270_2024-08-02T05-48-57Z](https://github.com/user-attachments/assets/3f7934bb-4681-47ec-9440-a677f6cfd327)

-  標題建議橫書並置於上方，另外產品卡片較多的話可使用輪播效果，避免佔太多空間

![台灣水蜜桃](https://github.com/user-attachments/assets/6b29749c-858a-404e-883c-9fc6d5c9c604)
![牛番茄](https://github.com/user-attachments/assets/ec50bff9-0f84-48f7-ad4c-eb41817b81fe)

-  以電商網站來說，Banner 需要有比較明確的網頁標題與引導使用者進行下一步動作的按鈕（e.g. 註冊、購物），這樣能夠增加網站的轉換率

### **修改後**

**1. 類別 icon 區塊希望接著 Banner 顯示，加上底色稍微 padding 上下空間**

![CleanShot 2024-09-06 at 10 00 50](https://github.com/user-attachments/assets/2fb4afa9-6bbf-41b9-a11b-635b1c6cd710)

**2. 當瀏覽器寬度小於 750px 以下，自動顯示輪播效果**

**3. 標題橫書並置於上方**

![CleanShot 2024-09-06 at 10 06 02](https://github.com/user-attachments/assets/218b1fa0-bcd5-4936-9e14-f12f09e854d5)

![CleanShot 2024-09-06 at 10 14 30](https://github.com/user-attachments/assets/2bd80f21-eccc-4b4b-a31a-a48b5915db17)

**4. 優惠區塊使用粗體字，去逛逛改用按鈕樣式，並直接顯示**

![CleanShot 2024-09-06 at 10 16 42](https://github.com/user-attachments/assets/efb8084b-ba8d-44f7-9625-5f2082c1546c)

**5. 加上 banner 上的文字及前往購物的按鈕，以及向下滑的指示 **

![CleanShot 2024-09-10 at 09 19 49](https://github.com/user-attachments/assets/8a50c02d-541d-42d9-8ebd-0e2bd04ccd12)
