### PR TITLE
Update pagenation position

### DIFF
--- a/src/components/PaginationView.vue
+++ b/src/components/PaginationView.vue
@@ -1,5 +1,5 @@
 <template>
-  <nav aria-label="Page navigation">
+  <nav class="mb-5 py-3" aria-label="Page navigation">
     <ul class="pagination my-3 justify-content-center">
       <li class="page-item">
         <a

--- a/src/components/PaginationView.vue
+++ b/src/components/PaginationView.vue
@@ -1,5 +1,5 @@
 <template>
-  <nav class="mb-5 py-3" aria-label="Page navigation">
+  <nav class="mb-4 py-3" aria-label="Page navigation">
     <ul class="pagination my-3 justify-content-center">
       <li class="page-item">
         <a

--- a/src/views/backend/Admin'sProducts.vue
+++ b/src/views/backend/Admin'sProducts.vue
@@ -1,6 +1,6 @@
 <template>
   <LoadingView v-if="isLoading" />
-  <main v-else class="px-3 d-flex flex-column align-items-center">
+  <main v-else class="wrap px-3 d-flex flex-column align-items-center">
     <header
       class="row m-0 p-2 col-12 col-xxl-11 justify-content-between align-items-center"
     >
@@ -272,6 +272,10 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+.wrap {
+  margin-top: 120px;
+}
+
 img {
   height: 20vh;
   width: 100%;

--- a/src/views/backend/Admin'sProducts.vue
+++ b/src/views/backend/Admin'sProducts.vue
@@ -1,6 +1,6 @@
 <template>
   <LoadingView v-if="isLoading" />
-  <main v-else class="px-3 mb-5 d-flex flex-column align-items-center">
+  <main v-else class="px-3 d-flex flex-column align-items-center">
     <header
       class="row m-0 p-2 col-12 col-xxl-11 justify-content-between align-items-center"
     >
@@ -22,7 +22,7 @@
       v-for="item in products"
       :key="item.id"
       :class="{ 'bg-light': item.is_enabled === 0 }"
-      class="row m-0 col-12 col-xxl-11 justify-content-center align-items-center py-2 border-top text-center text-sm-start"
+      class="row m-0 mb-5 col-12 col-xxl-11 justify-content-center align-items-center py-2 border-top text-center text-sm-start"
     >
       <div
         class="position-relative text-center col-4 col-sm-6 col-md-3 col-lg-2"

--- a/src/views/backend/AdminCoupons.vue
+++ b/src/views/backend/AdminCoupons.vue
@@ -1,6 +1,6 @@
 <template>
   <LoadingView v-if="isLoading" />
-  <div v-else>
+  <div v-else class="wrap">
     <header
       class="mx-auto mb-2 col-11 col-md-10 col-lg-11 col-xl-10 d-flex justify-content-between align-items-center flex-wrap"
     >
@@ -195,3 +195,9 @@ export default {
   },
 };
 </script>
+
+<style>
+.wrap {
+  margin-top: 120px;
+}
+</style>

--- a/src/views/backend/AdminDashboard.vue
+++ b/src/views/backend/AdminDashboard.vue
@@ -1,9 +1,9 @@
 <template>
-  <div class="navContainer">
+  <div>
     <AdminNavbar />
   </div>
 
-  <div class="viewContainer">
+  <div>
     <router-view />
   </div>
 </template>
@@ -34,9 +34,3 @@ export default {
   },
 };
 </script>
-
-<style lang="scss" scoped>
-.navContainer {
-  margin-bottom: 100px;
-}
-</style>

--- a/src/views/backend/AdminOrderList.vue
+++ b/src/views/backend/AdminOrderList.vue
@@ -208,7 +208,7 @@ export default {
 
 <style lang="scss" scoped>
 .containerWrap {
-  min-height: 88vh;
+  margin-top: 120px;
 }
 
 .accordion-button:hover {

--- a/src/views/backend/AdminOrderList.vue
+++ b/src/views/backend/AdminOrderList.vue
@@ -4,7 +4,7 @@
     v-else
     class="mx-auto containerWrap d-flex flex-column justify-content-between col-12 col-xl-10"
   >
-    <div class="mb-5">
+    <div class="">
       <header>
         <h3 v-if="noResults">{{ noResultsContent }}</h3>
         <div v-else class="p-1 mb-2 text-end">

--- a/src/views/backend/AdminQA.vue
+++ b/src/views/backend/AdminQA.vue
@@ -1,6 +1,6 @@
 <template>
   <LoadingView v-if="isLoading" />
-  <main v-else class="mx-auto col-11 col-md-10 col-lg-8">
+  <main v-else class="wrap mx-auto col-11 col-md-10 col-lg-8">
     <header
       class="px-1 mb-2 d-flex justify-content-between align-items-center flex-wrap"
     >
@@ -196,6 +196,10 @@ export default {
 };
 </script>
 <style lang="scss" scoped>
+.wrap {
+  margin-top: 120px;
+}
+
 .accordion-button:hover {
   color: #ccaf3c !important;
 }

--- a/src/views/backend/AdminQA.vue
+++ b/src/views/backend/AdminQA.vue
@@ -1,6 +1,6 @@
 <template>
   <LoadingView v-if="isLoading" />
-  <main v-else class="mx-auto mb-5 col-11 col-md-10 col-lg-8">
+  <main v-else class="mx-auto col-11 col-md-10 col-lg-8">
     <header
       class="px-1 mb-2 d-flex justify-content-between align-items-center flex-wrap"
     >
@@ -14,7 +14,7 @@
       </button>
     </header>
 
-    <section class="accordion containerWrap" id="QAList">
+    <section class="accordion" id="QAList">
       <div
         v-for="(item, index) in QA_List"
         :key="item.id"
@@ -196,10 +196,6 @@ export default {
 };
 </script>
 <style lang="scss" scoped>
-.containerWrap {
-  min-height: 73vh;
-}
-
 .accordion-button:hover {
   color: #ccaf3c !important;
 }

--- a/src/views/frontend/UserOrderList.vue
+++ b/src/views/frontend/UserOrderList.vue
@@ -4,7 +4,7 @@
     v-else
     class="listContainer mx-auto d-flex flex-column justify-content-between col-12 col-xl-10"
   >
-    <div class="mb-5">
+    <div class="">
       <h3 v-if="noResults" class="pt-4 ps-5">{{ noResultsContent }}</h3>
       <section
         v-for="(item, index) in orderList"
@@ -48,7 +48,7 @@
         </div>
       </section>
     </div>
-    <footer>
+    <footer class="">
       <PaginationView
         v-if="pageSwitch"
         :pages="pagination"
@@ -169,6 +169,5 @@ export default {
 
 .listContainer {
   margin-top: 120px;
-  min-height: 76vh;
 }
 </style>

--- a/src/views/frontend/UserQA.vue
+++ b/src/views/frontend/UserQA.vue
@@ -1,14 +1,11 @@
 <template>
   <LoadingView v-if="isLoading" />
-  <main v-else class="mt-5 pt-5 mx-auto col-11 col-md-10 col-lg-8">
+  <main v-else class="userQAWrap mx-auto col-11 col-md-10 col-lg-8">
     <header class="my-4 text-center">
       <h3 class="mb-0">常見問題</h3>
     </header>
 
-    <section
-      class="containerWrap accordion mb-4"
-      id="accordionPanelsStayOpenExample"
-    >
+    <section class="accordion" id="accordionPanelsStayOpenExample">
       <div
         v-for="(item, index) in QA_List"
         :key="item.id"
@@ -33,7 +30,7 @@
         </div>
       </div>
     </section>
-    <footer>
+    <footer class="">
       <PaginationView :pages="pagination" @emit-pages="getQAList">
       </PaginationView>
     </footer>
@@ -81,8 +78,8 @@ export default {
 };
 </script>
 <style lang="scss" scoped>
-.containerWrap {
-  min-height: 62vh;
+.userQAWrap {
+  margin-top: 120px;
 }
 
 .accordion-button:hover {


### PR DESCRIPTION
### **設計師建議**

-  Pagination 和上方內容屬於同一個資訊群組，距離應該近一些，但目前反而離 Footer （另一個資訊群組）更近

![FRESHI BOX](https://github.com/user-attachments/assets/196ee318-eed8-455f-ba56-f15a4c6b84ef)


手機版
-  常見問題頁：pagination 與 footer 的間距可以再大一些（24px 左右）

![FRESH BOX](https://github.com/user-attachments/assets/6402ec0a-ce4b-4082-9e88-60edc47d4587)

### **修改後**
1. 調整頁碼與footer及內容的間距

![CleanShot 2024-09-11 at 14 23 12](https://github.com/user-attachments/assets/be631df7-1a3e-4e1c-adf2-541e195bf45d)

![CleanShot 2024-09-11 at 14 25 52](https://github.com/user-attachments/assets/a1a55576-c460-4bbb-b788-6b9a11c1a5c2)

2. 行動版的頁碼間距

![CleanShot 2024-09-11 at 14 27 06](https://github.com/user-attachments/assets/63c10202-c5e4-419a-8dd3-5648837f52c6)
