### PR TITLE
update footer

### DIFF
--- a/src/components/frontend/FooterView.vue
+++ b/src/components/frontend/FooterView.vue
@@ -1,75 +1,66 @@
 <template>
-  <div class="row m-0 py-2 ps-4 bg-light fw-light">
-    <div class="row m-0 align-items-center justify-content-between col-12">
-      <div class="col-12 col-sm-6">
-        <router-link
-          to="/"
-          class="text-decoration-none text-dark textStyle fs-5 logoStyle"
-        >
-          FRESH BOX
-        </router-link>
-      </div>
-
-      <div
-        class="col-12 col-sm-6 row m-0 align-items-center justify-content-between p-0 flex-wrap"
+  <main class="bg-light">
+    <div
+      class="px-3 py-1 border-bottom d-flex flex-wrap justify-content-between align-items-center"
+    >
+      <router-link
+        to="/"
+        class="mb-0 ps-1 pe-3 textStyle linkStyle fs-4 text-dark"
       >
-        <div style="min-width: 145px" class="text-sm-end py-2 col">
-          <router-link
-            to="/login"
-            class="text-decoration-none rounded-pill text-center bg-black text-light py-2 px-3 adminLogin"
-          >
-            後台
-          </router-link>
-        </div>
-
+        FRESH BOX
+      </router-link>
+      <div class="d-flex align-items-center ps-1 py-1 pe-1">
+        <router-link to="/login" class="backendLink btn btn-black me-3 py-1">
+          後台
+        </router-link>
         <a
-          class="text-center text-sm-end col-auto"
+          class="bi bi-github fs-1 text-dark"
           href="https://github.com/c711cat/fresh_box"
         >
-          <i class="bi bi-github text-dark fs-1"></i>
         </a>
       </div>
     </div>
-    <div class="row m-0 col-12 textSize">
-      <span class="col-auto"> 此網站為個人作品展示，非商業用途。 </span>
-      <div class="col-auto">
+    <div class="px-3 py-3 d-flex flex-wrap">
+      <div class="textStyle pe-2">
         <a
-          class="text-decoration-none"
+          class="linkStyle text-dark"
           target="_blank"
           href="https://icons8.com/icons/collections/x6c5ehv2qqdv25m8idkq"
         >
-          category
+          Category
         </a>
         icons by
         <a
-          class="text-decoration-none"
+          class="linkStyle text-dark"
           target="_blank"
           href="https://icons8.com"
         >
           Icons8
         </a>
+        .
       </div>
-      <div class="textStyle col-auto">© 2024 FRESH BOX</div>
+      <span class="pe-2">此網站為個人作品展示，非商業用途。</span>
+      <span class="textStyle">© 2024 FRESH BOX</span>
     </div>
-  </div>
+  </main>
 </template>
-
 <style lang="scss" scoped>
-.textStyle {
-  font-family: "Times New Roman", Times, serif;
+a {
+  text-decoration: none;
 }
 
-.logoStyle:hover,
+.linkStyle:hover,
 .bi-github:hover {
   color: #ccaf3c !important;
 }
 
-.adminLogin:hover {
-  background-color: #ccaf3c !important;
-  color: black !important;
+.textStyle {
+  font-family: "Times New Roman", Times, serif;
 }
 
-.textSize {
-  font-size: 15px;
+.backendLink:hover {
+  background-color: #ccaf3c;
+  color: black;
+  border: 1px solid #ccaf3c;
 }
 </style>


### PR DESCRIPTION
### **設計師建議**

-  Logo 的視覺權重可以再重一些（字級 24px 左右）
-  上下 padding 可以再大一些（24px 左右）
-  目前只有著作權聲明使用明體，建議統一字體，整體視覺會比較有一致性

![17537644344834531270_2024-08-02T05-49-50Z](https://github.com/user-attachments/assets/7e6fa9fa-5a35-4633-af28-87e4639c5638)

手機版
-  Footer 排版略顯凌亂，建議可以參考 [學長姐作品](https://snershen.github.io/RECA-Bookstore/#/products) 重新安排佈局

![FRESH BOX](https://github.com/user-attachments/assets/cd063f1d-bd28-4105-8442-ae857b2c307b)

![+ RECA](https://github.com/user-attachments/assets/5403a2b3-a729-4228-b170-8d6febebad5c)

### **修改後**

**1. Logo  24px ，英文字母統一字體**

![CleanShot 2024-09-12 at 14 18 15](https://github.com/user-attachments/assets/316109f6-64ce-4d60-b78c-5e0f96175dc2)

**2. 上下 padding 24px**

![CleanShot 2024-09-12 at 14 21 43](https://github.com/user-attachments/assets/5c3fdd64-a7e8-42b8-b71e-16bee51f6c40)

![CleanShot 2024-09-12 at 14 23 10](https://github.com/user-attachments/assets/afd5bd63-399e-4a3d-9608-edd10e5a5fa4)