### PR TITLE
Designer suggestions

### DIFF
--- a/src/components/OrderView.vue
+++ b/src/components/OrderView.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="row m-0 p-0">
-    <div class="detailsText mb-4 col-lg-7">
+    <section class="px-4 detailsText mb-4 col-lg-7">
       <header
         class="d-flex align-items-center justify-content-between flex-wrap"
       >
@@ -147,8 +147,8 @@
           </strong>
         </div>
       </section>
-    </div>
-    <section class="col-lg-5">
+    </section>
+    <section class="px-4 col-lg-5">
       <h3 class="border-bottom pb-2">收件人資訊</h3>
       <div class="px-4 mb-2 d-flex flex-wrap">
         <p class="mb-0 py-1 fw-bold col-sm-2 col-12">姓名</p>

--- a/src/components/frontend/StepperView.vue
+++ b/src/components/frontend/StepperView.vue
@@ -1,9 +1,10 @@
 <template>
   <div class="d-flex justify-content-between align-items-center col-12">
     <p
-      class="col-2 col-sm-auto flex-wrap mb-0 fs-5 text-primary border border-primary p-2 text-center rounded"
+      class="col-3 col-sm-auto flex-wrap mb-0 text-primary border border-primary text-center rounded"
+      :class="textFontSize"
     >
-      建立<br class="d-block d-sm-none" />訂單
+      建立訂單
     </p>
 
     <div class="position-relative w-100 mx-2 d-flex align-items-center">
@@ -12,10 +13,10 @@
     </div>
 
     <p
-      class="col-2 col-sm-auto mb-0 fs-5 border p-2 text-center rounded"
-      :class="payingText"
+      class="col-3 col-sm-auto mb-0 border text-center rounded"
+      :class="[payingText, textFontSize]"
     >
-      進行<br class="d-block d-sm-none" />付款
+      進行付款
     </p>
 
     <div class="position-relative w-100 mx-2 d-flex align-items-center">
@@ -24,10 +25,10 @@
     </div>
 
     <p
-      class="col-2 col-sm-auto mb-0 fs-5 border p-2 text-center rounded"
-      :class="paidText"
+      class="col-3 col-sm-auto mb-0 border text-center rounded"
+      :class="[paidText, textFontSize]"
     >
-      付款<br class="d-block d-sm-none" />完成
+      付款完成
     </p>
   </div>
 </template>
@@ -37,6 +38,7 @@ export default {
   data() {
     return {
       order: {},
+      currentWidth: 1000,
     };
   },
   methods: {
@@ -50,6 +52,9 @@ export default {
         .catch((error) => {
           this.$pushMsg.status404(error.response.data.message);
         });
+    },
+    getCurrentWidth() {
+      this.currentWidth = window.innerWidth;
     },
   },
   computed: {
@@ -81,8 +86,16 @@ export default {
         return "border-gray-light";
       }
     },
+    textFontSize() {
+      if (this.currentWidth <= 575) {
+        return "xsFontSize p-1";
+      } else {
+        return "fs-5 p-2";
+      }
+    },
   },
   created() {
+    this.getCurrentWidth();
     if (this.$route.params.orderId) {
       this.getOrder();
     }
@@ -102,5 +115,9 @@ export default {
 
 .right {
   transform: rotate(-45deg);
+}
+
+.xsFontSize {
+  font-size: 14px;
 }
 </style>

--- a/src/views/frontend/CartView.vue
+++ b/src/views/frontend/CartView.vue
@@ -12,7 +12,7 @@
     </section>
     <main
       v-else
-      class="cartWrap col-sm-11 col-md-9 col-lg-10 mx-auto d-flex flex-wrap bg-light rounded"
+      class="p-3 cartWrap col-sm-11 col-md-9 col-lg-10 mx-auto d-flex flex-wrap bg-light rounded"
     >
       <div class="col-12 p-3">
         <router-view />

--- a/src/views/frontend/CartView.vue
+++ b/src/views/frontend/CartView.vue
@@ -14,12 +14,12 @@
       v-else
       class="p-3 cartWrap col-sm-11 col-md-9 col-lg-10 mx-auto d-flex flex-wrap bg-light rounded"
     >
-      <div class="col-12 p-3">
+      <div class="col-12 p-4">
         <router-view />
       </div>
-      <div class="col-12 col-lg-6 my-3">
+      <div class="col-12 col-lg-6 my-3 px-4">
         <header
-          class="col-12 d-flex flex-wrap justify-content-between align-items-center ps-3 pe-3 mb-2"
+          class="col-12 d-flex flex-wrap justify-content-between align-items-center mb-2 pe-3"
         >
           <h3 class="m-0">購買清單</h3>
           <button
@@ -30,7 +30,7 @@
             清空購物車
           </button>
         </header>
-        <div class="col-12 ps-3">
+        <div class="col-12">
           <section
             v-for="item in carts"
             :key="item.id"
@@ -164,7 +164,7 @@
           </section>
         </div>
       </div>
-      <section class="col-12 col-lg-6 py-3 ps-3 pe-3">
+      <section class="col-12 col-lg-6 my-3 px-4">
         <RecipientForm class="h-100" />
       </section>
     </main>

--- a/src/views/frontend/CartView.vue
+++ b/src/views/frontend/CartView.vue
@@ -111,7 +111,7 @@
                 :options="couponOption"
                 v-model="couponCode"
                 :disabled="used_coupon"
-                placeholder="使用優惠碼"
+                placeholder="套用優惠碼"
               ></v-select>
               <button
                 @click="useCoupon"
@@ -125,7 +125,7 @@
                 >
                   <span class="visually-hidden">Loading...</span>
                 </div>
-                <p v-else class="m-0">送出</p>
+                <p v-else class="m-0">套用</p>
               </button>
             </div>
 

--- a/src/views/frontend/HomeView.vue
+++ b/src/views/frontend/HomeView.vue
@@ -34,7 +34,7 @@
   <!-- 暢銷商品 -->
   <section class="mx-auto mb-5 col-11 col-xl-9">
     <h3
-      class="mb-3 border-bottom border-dark"
+      class="mb-3 border-bottom border-dark pb-2"
       data-aos="fade-in"
       data-aos-easing="ease-out-sine"
       data-aos-duration="1500"
@@ -50,7 +50,7 @@
   <!-- 精選商品 -->
   <section class="mx-auto mb-5 col-11 col-xl-9">
     <h3
-      class="mb-3 border-bottom border-dark"
+      class="mb-3 border-bottom border-dark pb-2"
       data-aos="fade-in"
       data-aos-easing="ease-out-sine"
       data-aos-duration="1500"

--- a/src/views/frontend/UserOrder.vue
+++ b/src/views/frontend/UserOrder.vue
@@ -1,9 +1,9 @@
 <template>
   <LoadingView v-if="isLoading" />
   <main v-else class="mt-5 pt-4 mb-5">
-    <div class="d-flex justify-content-center col-12 mt-4 mb-3 py-3 bg-light">
+    <div class="d-flex justify-content-center col-12 mt-4 mb-3 py-3">
       <div
-        class="col-11 col-sm-11 col-md-10 col-lg-11 col-xl-10 col-xxl-11 px-3"
+        class="col-11 col-sm-11 col-md-10 col-lg-11 col-xl-10 col-xxl-11 px-4"
       >
         <router-view />
       </div>
@@ -12,7 +12,7 @@
       class="mx-2 mx-auto col-11 col-sm-11 col-md-10 col-lg-11 col-xl-10 col-xxl-11"
     >
       <OrderView class="pt-2 mb-3" :transOrder="order" />
-      <section class="col-12 col-lg-5 px-2 ms-auto">
+      <section class="col-12 col-lg-5 px-4 ms-auto">
         <div
           v-if="order.is_paid"
           class="col-12 d-flex flex-wrap justify-content-between"

--- a/src/views/frontend/UserOrder.vue
+++ b/src/views/frontend/UserOrder.vue
@@ -17,14 +17,17 @@
           v-if="order.is_paid"
           class="col-12 d-flex flex-wrap justify-content-between"
         >
+          <router-link to="/order-list" class="border-0 col p-1">
+            <button
+              type="button"
+              class="w-100 btnBody btn btn-outline-secondary"
+            >
+              查看訂單
+            </button>
+          </router-link>
           <router-link to="/user-products" class="border-0 col p-1">
             <button type="button" class="w-100 btnBody btn btn-outline-primary">
               繼續逛逛
-            </button>
-          </router-link>
-          <router-link to="/order-list" class="border-0 col p-1">
-            <button type="button" class="w-100 btnBody btn btn-outline-dark">
-              查看訂單
             </button>
           </router-link>
         </div>

--- a/src/views/frontend/UserProducts.vue
+++ b/src/views/frontend/UserProducts.vue
@@ -620,7 +620,7 @@ img {
 }
 
 .sticky-top {
-  top: 75px;
+  top: 61px;
 }
 
 .btnXs {


### PR DESCRIPTION

### **設計師建議**

**首頁｜**
-  標題與底線的間距建議可以再大一些，避免視覺上過於壓迫
![image](https://github.com/user-attachments/assets/fd5bda3c-8a2f-4ced-9a51-1ed108a08929)

**購物車｜**
-  套用優惠碼的 CTA 文字建議使用「套用」或「使用」，語意上會更符合套用優惠碼的情境
-  區塊四邊 padding 可以再大一些
-  「購買清單」與「使用者資訊」間的距離可以再大一些（結帳頁也有相同問題，建議可以一起調整哩）
![美发准 收件人資稅](https://github.com/user-attachments/assets/391190e0-3745-4aa3-ac5c-643ee062bc31)

**結帳表單｜**
-  主色對比度與視覺權重，目前次要按鈕看起來比主要按鈕更顯眼，另外主要 CTA 建議放在右邊
![17537644344834531270_2024-09-25T02-32-01Z](https://github.com/user-attachments/assets/e4b9c66c-81be-40fc-a32f-1a8035e812af)

**行動版｜**
-  產品列表：選單要使用 Sticky 的話，建議緊貼 Navbar ，目前滾動時選單與 Navbar 之間會透出底下內容，有一些些突兀
![FRESH BOX](https://github.com/user-attachments/assets/7de001c9-2b29-4159-a979-f5d6df970bc5)

-  購物車：Stepper 建議橫書，空間不足的話可以將字級調整為 16px 或 14px，箭頭長度也可以短一些


### **修改後**

-  標題與底線的間距調大一些，避免視覺上過於壓迫
 
![CleanShot 2024-09-27 at 11 28 58](https://github.com/user-attachments/assets/c490cd9c-269c-43c1-a613-0ec86107ef2e)

-  套用優惠碼的 CTA 文字使用「套用」，語意上更符合套用優惠碼的情境

![CleanShot 2024-09-27 at 11 30 56](https://github.com/user-attachments/assets/174bb02e-de70-434a-94e1-6a5819108d08)

-  區塊四邊 padding 再大一些

![CleanShot 2024-09-27 at 11 34 58](https://github.com/user-attachments/assets/47267b4c-0863-40db-8a59-d5f741ab3f10)
![CleanShot 2024-09-27 at 11 32 41](https://github.com/user-attachments/assets/c5555707-3a39-408c-a8fa-f8116c9398f8)

-  「購買清單」與「使用者資訊」間的距離再調大一些，結帳頁也一起調整

![CleanShot 2024-09-27 at 11 38 38](https://github.com/user-attachments/assets/a60e2668-bfbb-48e9-9e58-b2e87e34968e)
![CleanShot 2024-09-27 at 11 37 09](https://github.com/user-attachments/assets/a9f315f8-6ff0-4ba6-82fd-d92c5324dbf7)
![CleanShot 2024-09-27 at 11 42 04](https://github.com/user-attachments/assets/6d33d6ae-5eeb-473b-abb3-22f06266d75f)
![CleanShot 2024-09-27 at 11 40 41](https://github.com/user-attachments/assets/fc44a9c8-560e-4727-98cc-584104445343)

-  主色對比度與視覺權重，次要按鈕放左邊，並改為灰色，主要 CTA 按鈕放在右邊

![CleanShot 2024-09-27 at 11 43 57](https://github.com/user-attachments/assets/9806abe0-addb-48c4-a192-f8990e508508)

**行動版｜**
-  產品列表：選單要使用 Sticky 的話，建議緊貼 Navbar ，目前滾動時選單與 Navbar 之間會透出底下內容，有一些些突兀

![CleanShot 2024-09-27 at 11 48 40](https://github.com/user-attachments/assets/953cb95e-f11a-424b-84c7-b05b644908a0)

-  購物車：Stepper 改橫書，字級調整為 14px

![CleanShot 2024-09-27 at 11 53 53](https://github.com/user-attachments/assets/7054f5bb-03c3-401e-b37e-f5119069edee)

![CleanShot 2024-09-27 at 11 50 46](https://github.com/user-attachments/assets/e5ffb86e-5627-4629-a316-32abe46efe71)
